### PR TITLE
Add Optimize CPU Costs for Windows Licensing guide

### DIFF
--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-AccountCpuOptimization.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-AccountCpuOptimization.md
@@ -1,0 +1,171 @@
+# AWS Account — Windows EC2 Optimize CPUs Scanner
+
+Scans your AWS account for Windows and Windows+SQL Server license-included EC2 instances, then calculates the potential cost savings if [Optimize CPUs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html) (ThreadsPerCore = 1) were enabled.
+
+## Use case
+
+Windows and SQL Server license-included EC2 instances are billed per vCPU. On instances with SMT (Simultaneous Multithreading), each physical core presents as 2 vCPUs — doubling the license cost. Disabling SMT cuts the active vCPU count in half, which can reduce licensing costs by 20-45% depending on the license type.
+
+This script scans your running and stopped instances, identifies which ones are Microsoft License Included, and shows you the dollar impact of enabling Optimize CPUs per instance and across your account.
+
+It also identifies:
+- Instances that already have SMT disabled
+- Dedicated Host instances (license-only costs, no compute)
+- T-series (burstable) and .metal instances where Optimize CPUs doesn't apply
+- Instances that don't use SMT, such as AMD or T2 (no savings possible)
+- SQL Server instances subject to the 4-vCPU minimum billing
+
+## Getting started
+
+1. Sign in to the AWS Console
+2. Open [CloudShell](https://us-east-2.console.aws.amazon.com/cloudshell/home)
+3. [Upload the script](https://docs.aws.amazon.com/cloudshell/latest/userguide/getting-started.html#folder-upload)
+4. Run:
+
+```powershell
+pwsh
+.\Show-AccountCpuOptimization.ps1
+```
+
+## Requirements
+
+- PowerShell 7+ (pre-installed in CloudShell)
+- AWS Tools for PowerShell: `AWS.Tools.EC2`, `AWS.Tools.Pricing` (pre-installed in CloudShell)
+- IAM permissions: `ec2:DescribeInstances`, `ec2:DescribeInstanceTypes`, `ec2:DescribeRegions`, `pricing:GetProducts`
+
+## Usage
+
+```powershell
+# Scan current region (default: 730 hours)
+.\Show-AccountCpuOptimization.ps1
+
+# Scan all US regions
+.\Show-AccountCpuOptimization.ps1 -Region us
+
+# Scan all enabled regions with annual estimate
+.\Show-AccountCpuOptimization.ps1 -Hours year
+
+# Only SQL Standard and Enterprise instances
+.\Show-AccountCpuOptimization.ps1 -Region us -LicenseType SQLStandard,SQLEnterprise
+
+# Filter by tag
+.\Show-AccountCpuOptimization.ps1 -Region us-east-1 -Tag 'Env:Production'
+
+# Multiple tags (AND logic across keys)
+.\Show-AccountCpuOptimization.ps1 -Tag 'Env:Production', 'Team:DBA'
+
+# Multiple values for same tag (OR logic within key)
+.\Show-AccountCpuOptimization.ps1 -Tag 'Env:Production,Staging'
+
+# Export to CSV (auto-generated filename)
+.\Show-AccountCpuOptimization.ps1 -OutputCsv
+
+# Export to HTML (can be opened in Excel, auto-generated filename)
+.\Show-AccountCpuOptimization.ps1 -OutputHtml
+
+# All options
+.\Show-AccountCpuOptimization.ps1 `
+    -Region us-east-1, us-east-2 `
+    -LicenseType SQLEnterprise `
+    -Tag 'Env:Production' `
+    -Hours year `
+    -OutputCsv `
+    -OutputHtml
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-Region` | all regions | One or more regions, prefixes (e.g. `us`, `eu-west`), or `all` |
+| `-Hours` | `730` | Number of hours, or `month` (730) / `year` (8760) |
+| `-LicenseType` | `All` | Filter: `All`, `Windows`, `SQL` (all SQL editions), `SQLWeb`, `SQLStandard`, `SQLEnterprise` |
+| `-Tag` | *(none)* | Filter by tag in `Key:Value` format. Comma-separated values for OR (`Env:Prod,Staging`). Multiple `-Tag` entries use AND logic |
+| `-OutputCsv` | off | Export to CSV with auto-generated filename |
+| `-OutputHtml` | off | Export to HTML with auto-generated filename (can be opened in Excel). TPC=2 rows are highlighted |
+| `-IncludeBYOL` | off | Include BYOL Windows instances (shown with `--` pricing) |
+
+## Example output
+
+```
+Region InstanceId          Name         InstanceType LicenseType   Cores TPC vCPUs Hours  Default $   TPC=1 $  Savings $  Savings % Note
+------ ----------          ----         ------------ -----------   ----- --- ----- ----- ---------- --------- ---------- ---------- ----
+use1   i-0abc123def456789a SQL-Prod     c6i.16xlarge SQLEnterprise    32   1    32   730    $49,617   $28,798   -$20,819      42.0% 3
+use1   i-0bcd234ef5678901b Web-App      c8a.xlarge   Windows           4   1     4   730       $292      $292         $0       0.0% 2
+use2   i-0cde345fg6789012c Dev-SQL      m8i.2xlarge  SQLStandard       4   2     8   730     $1,278      $794      -$485      37.9%
+use2   i-0def456gh7890123d DH-SQL       c5.4xlarge   SQLEnterprise     8   1     8   730     $2,459    $1,229    -$1,229      50.0% 1,3
+use2   i-0efg567hi8901234e Legacy       t3.2xlarge   Windows           4   2     8   730         --        --         --         -- 5
+
+Total Default TPC Setting:      $53,646
+Total if TPC set to 1:          $31,113
+Total Difference:              -$22,533
+Total Savings:                    42.0%
+
+Already saving (TPC=1):        -$22,048
+Potential new savings:            -$485
+
+  1 = Dedicated Host — only licensing costs were calculated (no instance compute cost)
+  2 = Instance type defaults to TPC=1 — no SMT to disable, savings = 0%
+  3 = Already running with TPC=1 (SMT disabled)
+  5 = T-series (burstable) — Optimize CPUs not applicable
+
+Scanned 2 region(s). Found 5 Windows instance(s).
+
+Default $ is based on On-Demand pricing.
+Savings $ is the same regardless of pricing model (On-Demand, Savings Plans, etc.) since
+   per-vCPU license rates are fixed.
+Note: Reserved Instances may not apply discounts with Optimize CPUs — use Savings Plans instead.
+```
+
+## Output columns
+
+| Column | Description |
+|---|---|
+| Region | Short region code (e.g. `use1`, `euw1`) |
+| InstanceId | EC2 instance ID |
+| Name | Instance Name tag (truncated to 19 chars) |
+| InstanceType | EC2 instance type |
+| LicenseType | Windows, SQLWeb, SQLStandard, or SQLEnterprise |
+| Cores | Default physical core count for the instance type (DescribeInstanceTypes API) |
+| TPC | Current ThreadsPerCore on the instance (DescribeInstances API) |
+| vCPUs | Current active vCPU count on the instance (DescribeInstances API: CoreCount × TPC) |
+| Hours | Hours used for cost calculation |
+| Default $ | On-Demand combined rate for the instance type, or license-only for Dedicated Hosts |
+| TPC=1 $ | Calculated: Linux base rate + (Cores × per-vCPU license rate), or license-only for Dedicated Hosts |
+| Savings $ | Cost difference (negative = savings) |
+| Savings % | Percentage savings |
+| Note | Numbered notes indicating special conditions (see legend below output) |
+
+## Notes legend
+
+| Note | Meaning |
+|---|---|
+| 1 | Dedicated Host — only licensing costs were calculated (no instance compute cost) |
+| 2 | Instance type defaults to TPC=1 — no SMT to disable, savings = 0% |
+| 3 | Already running with TPC=1 (SMT disabled) |
+| 4 | SQL Server Standard/Enterprise minimum 4-vCPU billing applies |
+| 5 | T-series (burstable) — Optimize CPUs not applicable |
+| 6 | .metal — Optimize CPUs not applicable |
+
+Only notes that apply to instances in the scan are shown in the output legend.
+
+## Pricing notes
+
+- Default $ is based on On-Demand pricing from the AWS Pricing API.
+- Savings $ is the same regardless of pricing model (On-Demand, Savings Plans) since per-vCPU license rates are fixed.
+- Optimize CPUs supports On-Demand and Savings Plans. Reserved Instances may not apply discounts correctly — see [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html) for details.
+- For Dedicated Host instances, only the license portion is calculated since there is no per-instance compute cost.
+
+## General notes
+
+- Scans running, stopped, stopping, and pending instances.
+- Includes shared, dedicated, and host tenancy instances.
+- T-series (burstable) and .metal instances show `--` for Optimize CPUs costs.
+- AMD instances that don't use SMT will show 0% savings.
+- The Pricing API always queries `us-east-1` regardless of the instance's region.
+- Price and CPU info are cached per instance type to minimize API calls.
+
+## Author
+
+Craig Cooley (coolcrai@amazon.com) — February 2026
+Built with [Kiro](https://kiro.dev) IDE + Claude Opus 4.6

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-AccountCpuOptimization.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-AccountCpuOptimization.md
@@ -167,5 +167,5 @@ Only notes that apply to instances in the scan are shown in the output legend.
 
 ## Author
 
-Craig Cooley (coolcrai@amazon.com) — February 2026
+Craig Cooley — February 2026
 Built with [Kiro](https://kiro.dev) IDE + Claude Opus 4.6

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-OptimizedCpuCost.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-OptimizedCpuCost.md
@@ -155,5 +155,5 @@ Only notes that apply to instances in the output are shown in the legend.
 
 ## Author
 
-Craig Cooley (coolcrai@amazon.com) — March 2026
+Craig Cooley — March 2026
 Built with [Kiro](https://kiro.dev) IDE + Claude Opus 4.6

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-OptimizedCpuCost.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-OptimizedCpuCost.md
@@ -24,15 +24,6 @@ When you launch a Windows or Windows+SQL Server license-included EC2 instance wi
 
 With ThreadsPerCore = 1, active vCPUs = number of physical cores (half the default vCPU count on instances that use SMT/hyperthreading). This reduces the license portion of the bill.
 
-### Per-vCPU license rates
-
-| License                            | Rate            |
-|------------------------------------|-----------------|
-| Windows Server                     | $0.046/vCPU-hr  |
-| Windows + SQL Server Web           | $0.063/vCPU-hr  |
-| Windows + SQL Server Standard      | $0.166/vCPU-hr  |
-| Windows + SQL Server Enterprise    | $0.421/vCPU-hr  |
-
 Instances that don't use SMT by default (e.g. AMD r8a) will show 0% savings since they already run 1 thread per core.
 
 ## Getting started
@@ -42,24 +33,16 @@ The easiest way to run this script is from [AWS CloudShell](https://docs.aws.ama
 1. Sign in to the AWS Console
 2. Open [CloudShell](https://us-east-2.console.aws.amazon.com/cloudshell/home)
 3. [Upload the script file](https://docs.aws.amazon.com/cloudshell/latest/userguide/getting-started.html#folder-upload)
-4. Start PowerShell and run:
+4. Run `pwsh`
 
-```powershell
-pwsh
-.\Show-OptimizedCpuCost.ps1
-```
 
 ## Requirements
 
-- PowerShell 7+
-- AWS Tools for PowerShell modules:
+- PowerShell 7+  (preinstalled in CloudShell)
+- AWS Tools for PowerShell modules:  (all preinstalled in CloudShell)
   - `AWS.Tools.EC2`
   - `AWS.Tools.Pricing`
 - Valid AWS credentials with `ec2:DescribeInstanceTypes` and `pricing:GetProducts` permissions
-
-```powershell
-Install-Module AWS.Tools.EC2, AWS.Tools.Pricing -Scope CurrentUser
-```
 
 ## Usage
 

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-OptimizedCpuCost.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/README-Show-OptimizedCpuCost.md
@@ -1,0 +1,159 @@
+# Show-OptimizedCpuCost
+
+Calculate the cost savings of running EC2 Windows instances with [Optimize CPUs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html) enabled (ThreadsPerCore = 1).
+
+## Example scenario
+
+A customer running SQL Server Enterprise on an `r6i.16xlarge` (3rd Gen Intel Xeon / Ice Lake) could upgrade to an `r8i.16xlarge` (6th Gen Intel Xeon / Granite Rapids) and enable Optimize CPUs with ThreadsPerCore=1. The newer processors deliver higher per-core performance, so even with SMT disabled, reducing the active vCPU count from 64 to 32 while retaining all 32 physical cores, SQL Server throughput stays comparable or improves. Meanwhile, the monthly cost drops from about $22,900 to $13,100, saving roughly $9,800/month.
+
+```
+.\Show-OptimizedCpuCost.ps1 -InstanceType r6i.16xlarge, r8i.16xlarge -LicenseType SQLEnterprise
+
+Region InstanceType LicenseType   Cores TPC vCPUs Hours  Default $   TPC=1 $  Savings $  Savings % Note
+------ ------------ -----------   ----- --- ----- ----- ---------- --------- ---------- ---------- ----
+use1   r6i.16xlarge SQLEnterprise    32   2    64   730    $22,612   $12,778    -$9,835      43.5%
+use1   r8i.16xlarge SQLEnterprise    32   2    64   730    $22,914   $13,080    -$9,835      42.9%
+```
+
+## How it works
+
+When you launch a Windows or Windows+SQL Server license-included EC2 instance with Optimize CPUs (ThreadsPerCore = 1), AWS splits the billing into two line items:
+
+1. **Base compute cost** — the Amazon Linux On-Demand rate for the instance type
+2. **License fee** — active vCPUs x per-vCPU license rate
+
+With ThreadsPerCore = 1, active vCPUs = number of physical cores (half the default vCPU count on instances that use SMT/hyperthreading). This reduces the license portion of the bill.
+
+### Per-vCPU license rates
+
+| License                            | Rate            |
+|------------------------------------|-----------------|
+| Windows Server                     | $0.046/vCPU-hr  |
+| Windows + SQL Server Web           | $0.063/vCPU-hr  |
+| Windows + SQL Server Standard      | $0.166/vCPU-hr  |
+| Windows + SQL Server Enterprise    | $0.421/vCPU-hr  |
+
+Instances that don't use SMT by default (e.g. AMD r8a) will show 0% savings since they already run 1 thread per core.
+
+## Getting started
+
+The easiest way to run this script is from [AWS CloudShell](https://docs.aws.amazon.com/cloudshell/latest/userguide/welcome.html), which comes with PowerShell and AWS modules pre-installed, and credentials are automatically configured.
+
+1. Sign in to the AWS Console
+2. Open [CloudShell](https://us-east-2.console.aws.amazon.com/cloudshell/home)
+3. [Upload the script file](https://docs.aws.amazon.com/cloudshell/latest/userguide/getting-started.html#folder-upload)
+4. Start PowerShell and run:
+
+```powershell
+pwsh
+.\Show-OptimizedCpuCost.ps1
+```
+
+## Requirements
+
+- PowerShell 7+
+- AWS Tools for PowerShell modules:
+  - `AWS.Tools.EC2`
+  - `AWS.Tools.Pricing`
+- Valid AWS credentials with `ec2:DescribeInstanceTypes` and `pricing:GetProducts` permissions
+
+```powershell
+Install-Module AWS.Tools.EC2, AWS.Tools.Pricing -Scope CurrentUser
+```
+
+## Usage
+
+```powershell
+# Hourly cost comparison (default)
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge, m8i.32xlarge, m8i.48xlarge, m8a.48xlarge -LicenseType SQLEnterprise
+
+# Compare all license types for an instance
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -LicenseType All
+
+# Compare SQL editions only
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -LicenseType SQL
+
+# Monthly estimate
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge, m8i.32xlarge -LicenseType SQLEnterprise -Hours month
+
+# Annual estimate
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge, m8i.32xlarge -LicenseType SQLEnterprise -Hours year
+
+# Different region, show memory, export to CSV
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -Region us-west-2 -Memory -OutputCsv results.csv
+
+# Sort by absolute dollar savings
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge, m8i.32xlarge -LicenseType Windows -SortBy Savings
+
+# Show all sizes in a family
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i -LicenseType SQLEnterprise
+
+# All options
+.\Show-OptimizedCpuCost.ps1 `
+    -InstanceType m8i.16xlarge, m8i.32xlarge, m8i.48xlarge, m8a.48xlarge `
+    -LicenseType SQLEnterprise `
+    -Hours 730 `
+    -Region us-east-2 `
+    -SortBy Savings `
+    -Memory `
+    -OutputCsv results.csv
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-InstanceType` | `m8i.16xlarge` | One or more instance type names or family prefixes (e.g. `m8i`) |
+| `-LicenseType` | `Windows` | `Windows`, `SQLWeb`, `SQLStandard`, `SQLEnterprise`, `SQL` (all 3 SQL editions), or `All` (all 4) |
+| `-Region` | `us-east-1` | AWS region to query pricing for |
+| `-Hours` | `730` | Number of hours, or `month` (730) / `year` (8760) |
+| `-SortBy` | `SavingsPct` | Sort by `SavingsPct`, `Savings`, `Default`, `TPC1`, `vCPUs`, `Cores`, or `InstanceType` |
+| `-Memory` | off | Include a MemoryGiB column in the output |
+| `-OutputCsv` | *(none)* | Path to export results as CSV |
+
+## Example output
+
+```
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -LicenseType All
+
+Region InstanceType LicenseType   Cores TPC vCPUs Hours  Default $   TPC=1 $  Savings $  Savings % Note
+------ ------------ -----------   ----- --- ----- ----- ---------- --------- ---------- ---------- ----
+use1   m8i.16xlarge Windows          32   2    64   730     $4,622    $3,547    -$1,075      23.3%
+use1   m8i.16xlarge SQLWeb           32   2    64   730     $5,411    $3,944    -$1,467      27.1%
+use1   m8i.16xlarge SQLStandard      32   2    64   730    $10,228    $6,350    -$3,878      37.9%
+use1   m8i.16xlarge SQLEnterprise    32   2    64   730    $22,142   $12,307    -$9,835      44.4%
+
+Default $ is based on On-Demand pricing.
+Savings $ is the same regardless of pricing model (On-Demand, Savings Plans, etc.) since
+   per-vCPU license rates are fixed.
+Note: Reserved Instances may not apply discounts with Optimize CPUs — use Savings Plans instead.
+```
+
+## Notes legend
+
+| Note | Meaning |
+|---|---|
+| 1 | Instance type defaults to TPC=1 — no SMT to disable, savings = 0% |
+| 2 | SQL Server Standard/Enterprise minimum 4-vCPU billing applies |
+| 3 | T-series (burstable) — Optimize CPUs not applicable |
+| 4 | Instance too small for selected SQL edition |
+| 5 | .metal — Optimize CPUs not applicable |
+
+Only notes that apply to instances in the output are shown in the legend.
+
+## Pricing notes
+
+- Default $ is based on On-Demand pricing from the AWS Pricing API.
+- Savings $ is the same regardless of pricing model (On-Demand, Savings Plans) since per-vCPU license rates are fixed.
+- Optimize CPUs supports On-Demand and Savings Plans. Reserved Instances may not apply discounts correctly — see [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html) for details.
+
+## General notes
+
+- .metal instances show the Default price but `--` for Optimize CPUs costs.
+- The Pricing API is only available in `us-east-1` and `ap-south-1`. The script always queries `us-east-1` for pricing regardless of the `-Region` parameter.
+- Pipeline output is supported: `.\Show-OptimizedCpuCost.ps1 ... | Where-Object SavingsPct -gt 20`
+
+## Author
+
+Craig Cooley (coolcrai@amazon.com) — March 2026
+Built with [Kiro](https://kiro.dev) IDE + Claude Opus 4.6

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/Show-AccountCpuOptimization.ps1
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/Show-AccountCpuOptimization.ps1
@@ -1,0 +1,633 @@
+<#
+.SYNOPSIS
+    Scans EC2 instances for Microsoft License-Included workloads and calculates
+    potential Optimize CPUs savings by disabling SMT / hyperthreading (ThreadsPerCore = 1).
+
+.DESCRIPTION
+    Queries all running and stopped EC2 instances in the specified region(s),
+    identifies Windows and Windows+SQL Server license-included instances by their
+    UsageOperation, retrieves CPU topology and pricing, then calculates the cost
+    difference if ThreadsPerCore were set to 1.
+
+    Supports shared, dedicated, and host tenancy instances. For Dedicated Host
+    instances, only licensing costs are calculated (no instance compute cost).
+
+    Data sources:
+      Cores:     DescribeInstanceTypes API (default core count for the instance type)
+      TPC:       DescribeInstances API (current ThreadsPerCore on the specific InstanceID)
+      vCPUs:     DescribeInstances API (current CoreCount x current ThreadsPerCore for the specific InstanceID)
+      Default $: Pricing API (On-Demand combined rate), or license-only for Dedicated Hosts
+      TPC=1 $:   Calculated (Linux base rate + Cores x per-vCPU license rate), or license-only for Dedicated Hosts
+
+    Per-vCPU license rates (from AWS Optimize CPUs docs):
+      Windows Server:                       $0.046/vCPU-hr
+      Windows Server with SQL Server Web:   $0.063/vCPU-hr
+      Windows Server with SQL Server Std:   $0.166/vCPU-hr
+      Windows Server with SQL Server Ent:   $0.421/vCPU-hr
+
+    Default $ is based on On-Demand pricing. Savings $ is the same regardless of
+    pricing model (On-Demand, Savings Plans) since per-vCPU license rates are fixed.
+    Reserved Instances may not apply discounts with Optimize CPUs — use Savings Plans.
+
+.PARAMETER Region
+    One or more AWS regions, region prefixes (e.g. 'us', 'eu-west'), or 'all'.
+    Supports arrays: -Region us-east-1, us-east-2
+    Defaults to all enabled regions.
+
+.PARAMETER Hours
+    Number of hours for cost calculation, or 'month' (730) / 'year' (8760).
+    Defaults to 730.
+
+.PARAMETER OutputCsv
+    Export results to CSV. Filename is auto-generated:
+    CPULicenseOptimize-<account>-<MMdd-HHmm>.csv
+
+.PARAMETER OutputHtml
+    Export results to HTML. Filename is auto-generated:
+    CPULicenseOptimize-<account>-<MMdd-HHmm>.html
+    The HTML file can be opened in Excel. Rows with TPC=2 are highlighted.
+
+.PARAMETER IncludeBYOL
+    Include BYOL (Bring Your Own License) Windows instances in the output.
+    These show pricing as -- since BYOL licensing is managed externally.
+
+.PARAMETER Tag
+    Filter instances by tag in 'Key:Value' format. Multiple tags use AND logic.
+
+.PARAMETER LicenseType
+    Filter by license type. Accepts one or more of:
+      All, Windows, SQL (all SQL editions), SQLWeb, SQLStandard, SQLEnterprise
+    Defaults to All.
+
+.EXAMPLE
+    .\Show-AccountCpuOptimization.ps1
+    Scan current region for all Windows LI instances (730 hours).
+
+.EXAMPLE
+    .\Show-AccountCpuOptimization.ps1 -Hours year
+    Scan all enabled regions with annual cost estimate.
+
+.EXAMPLE
+    .\Show-AccountCpuOptimization.ps1 -Region us -LicenseType SQLStandard,SQLEnterprise
+    Scan all US regions for SQL Standard and Enterprise instances only.
+
+.EXAMPLE
+    .\Show-AccountCpuOptimization.ps1 -Region us-east-1 -Tag 'Env:Production' -OutputCsv
+    Scan us-east-1 filtered by tag, export to CSV.
+
+.EXAMPLE
+    .\Show-AccountCpuOptimization.ps1 -Region us -OutputHtml
+    Scan all US regions, export HTML report (can be opened in Excel).
+
+.EXAMPLE
+    .\Show-AccountCpuOptimization.ps1 -Region us-east -Tag 'auto-delete:no' -LicenseType SQLEnterprise -Hours year
+
+.NOTES
+    Author: Craig Cooley (coolcrai@amazon.com)
+    Built with: Kiro IDE + Claude Opus 4.6
+    Date: February 2026
+
+    Requires AWS Tools for PowerShell:
+      - AWS.Tools.EC2
+      - AWS.Tools.Pricing
+    Requires permissions: ec2:DescribeInstances, ec2:DescribeInstanceTypes,
+                          ec2:DescribeRegions, pricing:GetProducts
+#>
+
+[CmdletBinding()]
+param(
+    [string[]]$Region,
+
+    [string]$Hours = "730",
+
+    [switch]$OutputCsv,
+
+    [switch]$OutputHtml,
+
+    [switch]$IncludeBYOL,
+
+    [switch]$ShowState,
+
+    [string[]]$Tag,
+
+    [ValidateSet("All", "Windows", "SQL", "SQLWeb", "SQLStandard", "SQLEnterprise")]
+    [string[]]$LicenseType = @("All")
+)
+
+# ── Resolve hours ──
+$HoursNum = switch ($Hours.ToLower()) {
+    'month'  { 730 }
+    'year'   { 8760 }
+    default  {
+        if ($Hours -as [int]) { [int]$Hours }
+        else { throw "Invalid -Hours value '$Hours'. Use a number, 'month', or 'year'." }
+    }
+}
+
+# ── UsageOperation → License type mapping ──
+$OpToLicense = @{
+    'RunInstances:0002' = 'Windows'
+    'RunInstances:0006' = 'SQLStandard'
+    'RunInstances:0102' = 'SQLEnterprise'
+    'RunInstances:0202' = 'SQLWeb'
+    'RunInstances:0800' = 'Windows BYOL'
+}
+
+# ── Per-vCPU license rates ──
+$LicenseRates = @{
+    'Windows'        = 0.046
+    'SQLWeb'         = 0.063
+    'SQLStandard'    = 0.166
+    'SQLEnterprise'  = 0.421
+}
+
+# ── Pricing API filter values per license type ──
+$LicenseFilterMap = @{
+    'Windows'        = @{ OS = 'Windows'; SW = 'NA';      Op = 'RunInstances:0002' }
+    'SQLWeb'         = @{ OS = 'Windows'; SW = 'SQL Web'; Op = 'RunInstances:0202' }
+    'SQLStandard'    = @{ OS = 'Windows'; SW = 'SQL Std'; Op = 'RunInstances:0006' }
+    'SQLEnterprise'  = @{ OS = 'Windows'; SW = 'SQL Ent'; Op = 'RunInstances:0102' }
+}
+
+# ── Microsoft 4-core billing minimum ──
+$MinBillableVcpus = @{
+    'Windows'        = 1
+    'SQLWeb'         = 1
+    'SQLStandard'    = 4
+    'SQLEnterprise'  = 4
+}
+
+$PricingRegion = 'us-east-1'
+
+# ── Price cache to avoid repeated API calls for the same instance type + license ──
+$priceCache = @{}
+
+# ── Helper: query Pricing API for On-Demand hourly rate ──
+function Get-OnDemandPrice {
+    param(
+        [string]$InstanceTypeName,
+        [string]$OS,
+        [string]$PreInstalledSw,
+        [string]$Operation,
+        [string]$RegionCode,
+        [string]$PricingRgn
+    )
+
+    $cacheKey = "${InstanceTypeName}|${Operation}|${RegionCode}"
+    if ($priceCache.ContainsKey($cacheKey)) { return $priceCache[$cacheKey] }
+
+    $filters = @(
+        @{ Type = 'TERM_MATCH'; Field = 'instanceType';   Value = $InstanceTypeName },
+        @{ Type = 'TERM_MATCH'; Field = 'regionCode';     Value = $RegionCode },
+        @{ Type = 'TERM_MATCH'; Field = 'operatingSystem'; Value = $OS },
+        @{ Type = 'TERM_MATCH'; Field = 'preInstalledSw'; Value = $PreInstalledSw },
+        @{ Type = 'TERM_MATCH'; Field = 'tenancy';        Value = 'Shared' },
+        @{ Type = 'TERM_MATCH'; Field = 'operation';      Value = $Operation }
+    )
+
+    $raw = Get-PLSProduct -ServiceCode AmazonEC2 -Filter $filters -Region $PricingRgn -ErrorAction SilentlyContinue
+    $prices = @()
+
+    foreach ($jsonStr in $raw) {
+        $product = $jsonStr | ConvertFrom-Json
+        if ($product.product.attributes.capacitystatus -ne 'Used') { continue }
+        $onDemand = $product.terms.OnDemand
+        if (-not $onDemand) { continue }
+        $skuTerm = $onDemand.PSObject.Properties.Value | Select-Object -First 1
+        $usd = $skuTerm.priceDimensions.PSObject.Properties.Value.pricePerUnit.USD | Select-Object -First 1
+        if ($usd -and [decimal]$usd -gt 0) { $prices += [decimal]$usd }
+    }
+
+    $result = if ($prices.Count -gt 0) { ($prices | Measure-Object -Maximum).Maximum } else { $null }
+    $priceCache[$cacheKey] = $result
+    return $result
+}
+
+# ── CPU info cache ──
+$cpuCache = @{}
+function Get-CpuInfo {
+    param([string]$InstanceTypeName, [string]$Rgn)
+    if ($cpuCache.ContainsKey($InstanceTypeName)) { return $cpuCache[$InstanceTypeName] }
+    $info = Get-EC2InstanceType -InstanceType $InstanceTypeName -Region $Rgn
+    $cpuCache[$InstanceTypeName] = $info
+    return $info
+}
+
+# ── Generate default output filenames ──
+$acctId = try { (Get-STSCallerIdentity).Account } catch { '00000' }
+$acctSuffix = $acctId.Substring($acctId.Length - 5)
+$timestamp = Get-Date -Format 'MMdd-HHmm'
+$baseFilename = "CPULicenseOptimize-${acctSuffix}-${timestamp}"
+
+$csvPath  = if ($OutputCsv)  { "${baseFilename}.csv" }  else { $null }
+$htmlPath = if ($OutputHtml) { "${baseFilename}.html" } else { $null }
+
+# ── Determine regions to scan ──
+if ($Region -and $Region.Count -eq 1 -and $Region[0] -eq 'all') {
+    $regions = (Get-EC2Region -ErrorAction SilentlyContinue).RegionName
+} elseif ($Region) {
+    # Get all valid regions for prefix matching
+    $allRegions = (Get-EC2Region -ErrorAction SilentlyContinue).RegionName
+    $regions = @()
+    foreach ($r in $Region) {
+        # Exact match
+        if ($r -in $allRegions) {
+            $regions += $r
+        } else {
+            # Prefix match (e.g. "us-" matches us-east-1, us-east-2, us-west-1, us-west-2)
+            $matched = $allRegions | Where-Object { $_ -like "${r}*" }
+            if ($matched) {
+                $regions += $matched
+            } else {
+                Write-Warning "No regions matched '$r'."
+            }
+        }
+    }
+    $regions = $regions | Sort-Object -Unique
+    if ($regions.Count -gt 1) { }
+} else {
+    # Default to all enabled regions
+    $regions = (Get-EC2Region -ErrorAction SilentlyContinue).RegionName
+}
+
+# ── Windows LI usage operations we care about ──
+$windowsOps = @('RunInstances:0002', 'RunInstances:0006', 'RunInstances:0102', 'RunInstances:0202')
+$byolOps    = @('RunInstances:0800')
+
+$results = [System.Collections.Generic.List[PSObject]]::new()
+
+foreach ($rgn in $regions) {
+    Write-Verbose "Scanning $rgn ..."
+
+    # Build filters
+    $filters = @(
+        @{Name='instance-state-name'; Values=@('running','stopped','stopping','pending')}
+    )
+    # Add tag filters (format: "Key:Value" or "Key:Value1,Value2" for OR)
+    foreach ($t in $Tag) {
+        if ($t -match '^([^:]+):(.+)$') {
+            $tagKey = $Matches[1]
+            $tagValues = $Matches[2] -split ',' | ForEach-Object { $_.Trim() }
+            $filters += @{Name="tag:$tagKey"; Values=$tagValues}
+        }
+    }
+
+    # Get all non-terminated instances
+    try {
+        $reservations = Get-EC2Instance -Region $rgn -Filter $filters -ErrorAction Stop
+    } catch {
+        Write-Warning "Could not query instances in $rgn : $_"
+        continue
+    }
+
+    foreach ($reservation in $reservations) {
+        foreach ($inst in $reservation.Instances) {
+            $usageOp = $inst.UsageOperation
+
+            # Filter to Windows LI (and optionally BYOL)
+            $isLI   = $usageOp -in $windowsOps
+            $isBYOL = $usageOp -in $byolOps
+
+            if (-not $isLI -and -not ($IncludeBYOL -and $isBYOL)) { continue }
+
+            $instLicense = $OpToLicense[$usageOp]
+            if (-not $instLicense) { continue }
+
+            # Filter by LicenseType param
+            $effectiveLicenseTypes = @()
+            foreach ($lt in $LicenseType) {
+                if ($lt -eq 'SQL') { $effectiveLicenseTypes += @('SQLWeb', 'SQLStandard', 'SQLEnterprise') }
+                else { $effectiveLicenseTypes += $lt }
+            }
+            if ('All' -notin $effectiveLicenseTypes -and $instLicense -notin $effectiveLicenseTypes) { continue }
+
+            $instanceType = $inst.InstanceType
+            $instanceId   = $inst.InstanceId
+            $state        = $inst.State.Name
+            $tenancy      = $inst.Placement.Tenancy.Value
+            $currentCores = $inst.CpuOptions.CoreCount
+            $currentThreads = $inst.CpuOptions.ThreadsPerCore
+            $currentVcpus = $currentCores * $currentThreads
+            $isBurstable  = $instanceType -match '^t\d'
+            $isHost       = $tenancy -eq 'host'
+
+            # Instance name from tags
+            $nameTag = ($inst.Tags | Where-Object { $_.Key -eq 'Name' }).Value
+            if (-not $nameTag) { $nameTag = '--' }
+
+            # Get CPU topology for the instance type
+            try {
+                $cpuInfo = Get-CpuInfo -InstanceTypeName $instanceType -Rgn $rgn
+            } catch {
+                Write-Warning "Could not get CPU info for $instanceType : $_"
+                continue
+            }
+
+            $defaultVcpus  = $cpuInfo.VCpuInfo.DefaultVCpus
+            $defaultCores  = $cpuInfo.VCpuInfo.DefaultCores
+            $defaultThreads = $cpuInfo.VCpuInfo.DefaultThreadsPerCore
+            $noSmtVcpus    = $defaultCores  # instance type's default core count at TPC=1
+            $isMetal       = $cpuInfo.BareMetal
+
+            # Already has SMT disabled?
+            $smtDisabled = $currentThreads -eq 1 -and $defaultThreads -gt 1
+
+            # ── Calculate costs ──
+            $defaultCost  = $null
+            $noSmtCost    = $null
+            $difference   = $null
+            $savingsPct   = $null
+
+            if ($isLI -and -not $isBurstable -and -not $isMetal) {
+                $perVcpu = $LicenseRates[$instLicense]
+                $minBillable = $MinBillableVcpus[$instLicense]
+                $noSmtBillableVcpus = [math]::Max($noSmtVcpus, $minBillable)
+
+                if ($isHost) {
+                    # Host tenancy: no compute cost, license only (vCPUs × rate)
+                    $defaultCost = [math]::Round($defaultVcpus * $perVcpu * $HoursNum, 2)
+                    $noSmtCost   = [math]::Round($noSmtBillableVcpus * $perVcpu * $HoursNum, 2)
+
+                    if ($defaultThreads -eq 1) {
+                        $noSmtCost  = $defaultCost
+                        $difference = 0
+                        $savingsPct = 0
+                    } else {
+                        $difference = [math]::Round($noSmtCost - $defaultCost, 2)
+                        $savingsPct = if ($defaultCost -gt 0) {
+                            [math]::Round((($defaultCost - $noSmtCost) / $defaultCost) * 100, 1)
+                        } else { 0 }
+                    }
+                    $linuxRate = 0
+                } else {
+                    # Shared/dedicated tenancy: compute + license
+                    $wf = $LicenseFilterMap[$instLicense]
+                    if ($wf) {
+                        $windowsRate = Get-OnDemandPrice -InstanceTypeName $instanceType `
+                                                          -OS $wf.OS -PreInstalledSw $wf.SW `
+                                                          -Operation $wf.Op `
+                                                          -RegionCode $rgn -PricingRgn $PricingRegion
+
+                        $linuxRate = Get-OnDemandPrice -InstanceTypeName $instanceType `
+                                                        -OS 'Linux' -PreInstalledSw 'NA' `
+                                                        -Operation 'RunInstances' `
+                                                        -RegionCode $rgn -PricingRgn $PricingRegion
+
+                        if ($windowsRate -and $linuxRate) {
+                            $defaultCost = [math]::Round($windowsRate * $HoursNum, 2)
+
+                            $noSmtHourly = $linuxRate + ($noSmtBillableVcpus * $perVcpu)
+                            $noSmtCost   = [math]::Round($noSmtHourly * $HoursNum, 2)
+
+                            if ($defaultThreads -eq 1) {
+                                $noSmtCost  = $defaultCost
+                                $difference = 0
+                                $savingsPct = 0
+                            } else {
+                                $difference = [math]::Round($noSmtCost - $defaultCost, 2)
+                                $savingsPct = if ($windowsRate -gt 0) {
+                                    [math]::Round((($windowsRate - $noSmtHourly) / $windowsRate) * 100, 1)
+                                } else { 0 }
+                            }
+                        }
+                    }
+                }
+            }
+
+            # ── Build notes for this instance ──
+            $notes = @()
+            if ($isHost)                                          { $notes += '1' }
+            if ($defaultThreads -eq 1)                            { $notes += '2' }
+            if ($smtDisabled)                                     { $notes += '3' }
+            $minBillableCheck = if ($isBurstable) { $MinBillableVcpus[$instLicense] } else { $MinBillableVcpus[$instLicense] }
+            if ($noSmtVcpus -lt $minBillableCheck -and $minBillableCheck -gt 1) { $notes += '4' }
+            if ($isBurstable)                                     { $notes += '5' }
+            if ($isMetal)                                         { $notes += '6' }
+
+            $row = [PSCustomObject]@{
+                Region           = $rgn
+                InstanceId       = $instanceId
+                Name             = $nameTag
+                InstanceType     = $instanceType
+                State            = $state
+                PlatformDetails  = $inst.PlatformDetails
+                LicenseType      = $instLicense
+                DefaultVCpus     = $defaultVcpus
+                CurrentVCpus     = $currentVcpus
+                NoSMTvCpus       = $noSmtVcpus
+                ThreadsPerCore   = $currentThreads
+                SMTDisabled      = $smtDisabled
+                DefaultCost      = $defaultCost
+                NoSMTCost        = $noSmtCost
+                Difference       = $difference
+                SavingsPct       = $savingsPct
+                Hours            = $HoursNum
+                IsBurstable      = $isBurstable
+                IsMetal          = $isMetal
+                IsHost           = $isHost
+                DefaultThreadsPerCore = $defaultThreads
+                PerVcpuRate      = if ($isLI -and $LicenseRates[$instLicense]) { $LicenseRates[$instLicense] } else { 0 }
+                LinuxRate        = if ($linuxRate) { $linuxRate } else { 0 }
+                Notes            = if ($notes.Count -gt 0) { $notes -join ',' } else { '' }
+            }
+            $results.Add($row)
+        }
+    }
+}
+
+# ── Output ──
+Write-Host ""
+Write-Host "====================================================================================================" -ForegroundColor Yellow
+Write-Host " CPU Threads Per Core (TPC) License Optimization Report for Microsoft License Included EC2 Instances" -ForegroundColor Yellow
+Write-Host "====================================================================================================" -ForegroundColor Yellow
+
+if ($results.Count -eq 0) {
+    Write-Host "No Windows license-included instances found."
+    return
+}
+
+Write-Host ""
+
+# Money format
+if ($HoursNum -eq 1) {
+    $fmtDefault = { if ($null -eq $_.DefaultCost) { '--' } else { '${0:N2}' -f $_.DefaultCost } }
+    $fmtNoSMT   = { if ($null -eq $_.NoSMTCost)  { '--' } else { '${0:N2}' -f $_.NoSMTCost } }
+    $fmtDiff    = { if ($null -eq $_.Difference) { '--' } elseif ($_.Difference -lt 0) { '-${0:N2}' -f [math]::Abs($_.Difference) } elseif ($_.Difference -eq 0) { '$0.00' } else { '${0:N2}' -f $_.Difference } }
+} else {
+    $fmtDefault = { if ($null -eq $_.DefaultCost) { '--' } else { '${0:N0}' -f $_.DefaultCost } }
+    $fmtNoSMT   = { if ($null -eq $_.NoSMTCost)  { '--' } else { '${0:N0}' -f $_.NoSMTCost } }
+    $fmtDiff    = { if ($null -eq $_.Difference) { '--' } elseif ($_.Difference -lt 0) { '-${0:N0}' -f [math]::Abs($_.Difference) } elseif ($_.Difference -eq 0) { '$0' } else { '${0:N0}' -f $_.Difference } }
+}
+
+$cols = @(
+    @{N='Region'; E={
+        $r = $_.Region
+        $r = $r -replace 'us-east-',   'use'
+        $r = $r -replace 'us-west-',   'usw'
+        $r = $r -replace 'eu-west-',   'euw'
+        $r = $r -replace 'eu-central-','euc'
+        $r = $r -replace 'eu-north-',  'eun'
+        $r = $r -replace 'eu-south-',  'eus'
+        $r = $r -replace 'ap-northeast-','apne'
+        $r = $r -replace 'ap-southeast-','apse'
+        $r = $r -replace 'ap-south-',  'aps'
+        $r = $r -replace 'ca-central-','cac'
+        $r = $r -replace 'sa-east-',   'sae'
+        $r = $r -replace 'me-south-',  'mes'
+        $r = $r -replace 'af-south-',  'afs'
+        $r
+    }},
+    'InstanceId',
+    @{N='Name'; E={ if ($_.Name.Length -gt 19) { $_.Name.Substring(0,19) } else { $_.Name } }},
+    'InstanceType'
+)
+if ($ShowState) { $cols += 'State' }
+$cols += @(
+    'LicenseType',
+    @{N='Cores'; E={$_.NoSMTvCpus}; Align='Right'},
+    @{N='TPC'; E={$_.ThreadsPerCore}; Align='Right'},
+    @{N='vCPUs'; E={$_.CurrentVCpus}; Align='Right'},
+    @{N='Hours'; E={$_.Hours}; Align='Right'},
+    @{N=' Default $'; E=$fmtDefault; Align='Right'},
+    @{N='  TPC=1 $'; E=$fmtNoSMT;  Align='Right'},
+    @{N=' Savings $'; E=$fmtDiff;   Align='Right'},
+    @{N=' Savings %';  E={ if ($null -eq $_.SavingsPct) { '--' } else { '{0:N1}%' -f $_.SavingsPct } }; Align='Right'},
+    @{N='Note'; E={$_.Notes}}
+)
+
+$results | Sort-Object Region, LicenseType, { $_.DefaultCost } -Descending | Format-Table -Property $cols
+
+# Summary
+$potential   = $results | Where-Object { -not $_.SMTDisabled -and $_.Difference -and $_.Difference -lt 0 }
+
+$totalDefault = ($results | Where-Object { $_.DefaultCost } | Measure-Object -Property DefaultCost -Sum).Sum
+$totalNoSMT   = ($results | Where-Object { $_.NoSMTCost }  | Measure-Object -Property NoSMTCost -Sum).Sum
+$totalDiff    = $totalNoSMT - $totalDefault
+
+# Calculate "already saving" for instances at TPC=1 where TPC=2 is valid
+$alreadySaving = 0
+foreach ($r in $results) {
+    if ($r.SMTDisabled -and $r.DefaultThreadsPerCore -eq 2 -and $r.LinuxRate -gt 0) {
+        $minBillable = $MinBillableVcpus[$r.LicenseType]
+        $tpc2Vcpus = [math]::Max($r.NoSMTvCpus * 2, $minBillable)
+        $tpc2Hourly = $r.LinuxRate + ($tpc2Vcpus * $r.PerVcpuRate)
+        $tpc1Hourly = $r.LinuxRate + ([math]::Max($r.NoSMTvCpus, $minBillable) * $r.PerVcpuRate)
+        $alreadySaving += ($tpc1Hourly - $tpc2Hourly) * $HoursNum
+    }
+}
+$alreadySaving = [math]::Round($alreadySaving, 0)
+$newSavings    = if ($potential) { ($potential | Measure-Object -Property Difference -Sum).Sum } else { 0 }
+
+Write-Host ("Total cost with Default TPC Setting: {0,12:C0}" -f $totalDefault)
+Write-Host ("Total cost if TPC set to 1:          {0,12:C0}" -f $totalNoSMT)
+Write-Host ("Cost Difference:                     {0,12:C0}" -f $totalDiff)
+if ($totalDefault -gt 0) {
+    Write-Host ("Percent Savings:                     {0,11:N1}%" -f ((($totalDefault - $totalNoSMT) / $totalDefault) * 100))
+}
+Write-Host ""
+Write-Host ("Already saving with TPC=1:           {0,12:C0}" -f $alreadySaving)
+Write-Host ("Potential new savings:               {0,12:C0}" -f $newSavings)
+Write-Host ("* All figures are per $HoursNum hours.")
+
+# Footnotes — only show notes that appear in the results
+$allNotes = ($results | Where-Object { $_.Notes } | ForEach-Object { $_.Notes -split ',' }) | Sort-Object -Unique
+$noteDescriptions = @{
+    '1' = 'Dedicated Host — only licensing costs were calculated (no instance compute cost)'
+    '2' = 'Instance type defaults to TPC=1 — no SMT to disable, savings = 0%'
+    '3' = 'Already running with TPC=1 (SMT disabled)'
+    '4' = 'SQL Server Standard/Enterprise minimum 4-vCPU billing applies'
+    '5' = 'T-series (burstable) — Optimize CPUs not applicable'
+    '6' = '.metal — Optimize CPUs not applicable'
+}
+if ($allNotes.Count -gt 0) {
+    Write-Host ""
+    foreach ($n in $allNotes) {
+        if ($noteDescriptions.ContainsKey($n)) {
+            Write-Host "  $n = $($noteDescriptions[$n])" -ForegroundColor Yellow
+        }
+    }
+}
+
+# CSV export
+if ($csvPath) {
+    $results | Export-Csv -Path $csvPath -NoTypeInformation -Force
+    Write-Host ""
+    Write-Host "Results exported to $csvPath"
+}
+
+# HTML export
+if ($htmlPath) {
+    $css = @"
+<style>
+    body { font-family: Consolas, monospace; background: #1e1e1e; color: #d4d4d4; padding: 20px; }
+    h1 { color: #dcdcaa; }
+    table { border-collapse: collapse; width: 100%; }
+    th { background: #264f78; color: #fff; padding: 6px 10px; text-align: left; }
+    td { padding: 4px 10px; border-bottom: 1px solid #333; }
+    tr:hover { background: #2a2d2e; }
+    .tpc2 { background: #4e3a1a; }
+    .savings { color: #4ec9b0; }
+    .summary { margin-top: 20px; font-size: 14px; width: auto; }
+    .summary td { border: none; padding: 2px 6px; white-space: nowrap; }
+    .disclaimer { margin-top: 20px; font-size: 14px; color: #d4d4d4; line-height: 1.6; }
+</style>
+"@
+
+    $htmlRows = foreach ($r in ($results | Sort-Object Region, LicenseType, { $_.DefaultCost } -Descending)) {
+        $rowClass = if ($r.ThreadsPerCore -eq 2) { ' class="tpc2"' } else { '' }
+        $defaultFmt = if ($null -eq $r.DefaultCost) { '--' } else { '${0:N0}' -f $r.DefaultCost }
+        $noSmtFmt   = if ($null -eq $r.NoSMTCost)  { '--' } else { '${0:N0}' -f $r.NoSMTCost }
+        $diffFmt    = if ($null -eq $r.Difference) { '--' } elseif ($r.Difference -lt 0) { '-${0:N0}' -f [math]::Abs($r.Difference) } elseif ($r.Difference -eq 0) { '$0' } else { '${0:N0}' -f $r.Difference }
+        $savFmt     = if ($null -eq $r.SavingsPct) { '--' } else { '{0:N1}%' -f $r.SavingsPct }
+        $name       = if ($r.Name.Length -gt 19) { $r.Name.Substring(0,19) } else { $r.Name }
+        $noteFmt    = if ($r.Notes) { $r.Notes } else { '' }
+        "<tr$rowClass><td>$($r.Region)</td><td>$($r.InstanceId)</td><td>$name</td><td>$($r.InstanceType)</td><td>$($r.State)</td><td>$($r.LicenseType)</td><td align='right'>$($r.NoSMTvCpus)</td><td align='right'>$($r.ThreadsPerCore)</td><td align='right'>$($r.CurrentVCpus)</td><td align='right'>$($r.Hours)</td><td align='right'>$defaultFmt</td><td align='right'>$noSmtFmt</td><td align='right'>$diffFmt</td><td align='right'>$savFmt</td><td>$noteFmt</td></tr>"
+    }
+
+    $noteRows = foreach ($n in $allNotes) {
+        if ($noteDescriptions.ContainsKey($n)) { "<tr><td>$n</td><td>$($noteDescriptions[$n])</td></tr>" }
+    }
+
+    $html = @"
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>TPC Licensing Report</title>$css</head><body>
+<h1>CPU Threads Per Core (TPC) Licensing Report for Microsoft License Included EC2 Instances</h1>
+<table>
+<tr><th>Region</th><th>InstanceId</th><th>Name</th><th>InstanceType</th><th>State</th><th>LicenseType</th><th>Cores</th><th>TPC</th><th>vCPUs</th><th>Hours</th><th>Default $</th><th>TPC=1 $</th><th>Savings $</th><th>Savings %</th><th>Note</th></tr>
+$($htmlRows -join "`n")
+</table>
+<table class="summary">
+<tr><td>Total cost with Default TPC Setting:</td><td>$("{0:C0}" -f $totalDefault)</td></tr>
+<tr><td>Total cost if TPC set to 1:</td><td>$("{0:C0}" -f $totalNoSMT)</td></tr>
+<tr><td>Cost Difference:</td><td>$("{0:C0}" -f $totalDiff)</td></tr>
+<tr><td>Percent Savings:</td><td>$("{0:N1}%" -f ((($totalDefault - $totalNoSMT) / $totalDefault) * 100))</td></tr>
+<tr><td>&nbsp;</td><td></td></tr>
+<tr><td>Already saving with TPC=1:</td><td>$("{0:C0}" -f $alreadySaving)</td></tr>
+<tr><td>Potential new savings:</td><td>$("{0:C0}" -f $newSavings)</td></tr>
+<tr><td>All figures are per $HoursNum hours.</td><td></td></tr>
+</table>
+$(if ($noteRows) { "<table class='summary'><tr><th>Note</th><th>Description</th></tr>`n$($noteRows -join "`n")`n</table>" })
+<div class="disclaimer">
+Default $ and TPC=1 $ are based on On-Demand pricing.<br>
+Savings $ is the same regardless of pricing model (On-Demand, Savings Plans, etc.) since per-vCPU license rates are fixed.<br>
+Note: Reserved Instances may not apply discounts with Optimize CPUs &mdash; use Savings Plans instead.<br>
+See: <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html" style="color:#569cd6;">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html</a><br><br>
+Scanned $($regions.Count) region(s). Found $($results.Count) Windows instance(s).
+</div>
+</body></html>
+"@
+
+    $html | Out-File -FilePath $htmlPath -Encoding utf8 -Force
+    Write-Host ""
+    Write-Host "HTML report exported to $htmlPath"
+}
+
+Write-Host ""
+Write-Host "Scanned $($regions.Count) region(s). Found $($results.Count) Windows instance(s)."
+Write-Host ""
+Write-Host "Default $ and TPC=1 $ are based on On-Demand pricing." -ForegroundColor Cyan
+Write-Host "Savings $ is the same regardless of pricing model (On-Demand, Savings Plans, etc.) since" -ForegroundColor Cyan
+Write-Host "   per-vCPU license rates are fixed." -ForegroundColor Cyan
+Write-Host "Note: Reserved Instances may not apply discounts with Optimize CPUs — use Savings Plans instead." -ForegroundColor Cyan
+Write-Host "See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html" -ForegroundColor Cyan
+Write-Host "====================================================================================================" -ForegroundColor Yellow

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/Show-OptimizedCpuCost.ps1
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/CPUOptimizationCalc/Show-OptimizedCpuCost.ps1
@@ -1,0 +1,501 @@
+<#
+.SYNOPSIS
+    Calculates EC2 Windows instance costs when using Optimize CPUs (ThreadsPerCore = 1).
+
+.DESCRIPTION
+    Compares the standard Windows/SQL On-Demand hourly cost against the Optimize CPUs
+    cost when ThreadsPerCore is set to 1 (hyperthreading disabled).
+
+    Standard billing (no Optimize CPUs):
+      Single combined rate = Windows or Windows+SQL On-Demand price per hour
+
+    Optimize CPUs billing (ThreadsPerCore = 1):
+      Line 1: Amazon Linux On-Demand rate (base compute cost)
+      Line 2: Active vCPUs x per-vCPU license rate
+
+    With ThreadsPerCore = 1, active vCPUs = DefaultCores (typically half the
+    default vCPU count on instances that default to 2 threads per core).
+
+    Per-vCPU license rates (from AWS docs):
+      Windows Server:                       $0.046/vCPU-hr
+      Windows Server with SQL Server Web:   $0.063/vCPU-hr
+      Windows Server with SQL Server Std:   $0.166/vCPU-hr
+      Windows Server with SQL Server Ent:   $0.421/vCPU-hr
+
+    Default $ is based on On-Demand pricing. Savings $ is the same regardless of
+    pricing model (On-Demand, Savings Plans) since per-vCPU license rates are fixed.
+    Reserved Instances may not apply discounts with Optimize CPUs — use Savings Plans.
+
+.PARAMETER Region
+    AWS region to query pricing for. Defaults to us-east-1.
+
+.PARAMETER InstanceType
+    One or more EC2 instance type names (e.g. m8i.16xlarge) or family prefixes
+    (e.g. m8i) to expand all sizes in the family. Accepts pipeline input.
+    Default: m8i.16xlarge
+
+.PARAMETER Size
+    Filter expanded results to a specific size (e.g. 16xlarge, 4xlarge, xlarge).
+    Use with family prefixes to compare across families at a given size.
+    Example: -InstanceType m,r -Size 16xlarge
+
+.PARAMETER LicenseType
+    Which Windows license(s) to calculate. Accepts one or more of:
+      Windows, SQLWeb, SQLStandard, SQLEnterprise, SQL (all 3 SQL editions), All (all 4)
+    Defaults to Windows.
+
+.PARAMETER Hours
+    Number of hours to calculate costs for, or 'month' (730) / 'year' (8760).
+    Defaults to 730.
+
+.PARAMETER OutputCsv
+    Optional path to export results as CSV.
+
+.EXAMPLE
+    .\Show-OptimizedCpuCost.ps1
+    Run with defaults (m8i.16xlarge, Windows, 730 hours).
+
+.EXAMPLE
+    .\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge, m8i.32xlarge -LicenseType SQLEnterprise
+
+.EXAMPLE
+    .\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -LicenseType All
+    Compare all four license types for a single instance type.
+
+.EXAMPLE
+    .\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -LicenseType SQL
+    Compare SQL Web, Standard, and Enterprise for a single instance type.
+
+.EXAMPLE
+    .\Show-OptimizedCpuCost.ps1 -InstanceType m8i -LicenseType SQLEnterprise
+    Show all m8i family sizes with SQL Server Enterprise pricing.
+
+.EXAMPLE
+    .\Show-OptimizedCpuCost.ps1 -InstanceType m8i.16xlarge -Region us-west-2 -Memory -OutputCsv results.csv
+
+.NOTES
+    Author: Craig Cooley (coolcrai@amazon.com)
+    Built with: Kiro IDE + Claude Opus 4.6
+    Date: March 2026
+
+    Requires AWS Tools for PowerShell:
+      - AWS.Tools.EC2
+      - AWS.Tools.Pricing
+    The Pricing API is only available in us-east-1 and ap-south-1.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string[]]$InstanceType = @('m8i.16xlarge'),
+
+    [string]$Size,
+
+    [ValidateSet("Windows", "SQLWeb", "SQLStandard", "SQLEnterprise", "SQL", "All")]
+    [string[]]$LicenseType = @("Windows"),
+
+    [string]$Region = "us-east-1",
+
+    [string]$Hours = "730",
+
+    [string]$OutputCsv,
+
+    [switch]$Memory,
+
+    [ValidateSet("SavingsPct", "Savings", "Default", "TPC1", "InstanceType", "vCPUs", "Cores")]
+    [string[]]$SortBy = @("SavingsPct")
+)
+
+begin {
+    # ── Resolve -Hours shorthand ──
+    $HoursNum = switch ($Hours.ToLower()) {
+        'month'  { 730 }
+        'year'   { 8760 }
+        default  {
+            if ($Hours -as [int]) { [int]$Hours }
+            else { throw "Invalid -Hours value '$Hours'. Use a number, 'month', or 'year'." }
+        }
+    }
+
+    # ── Per-vCPU license rates (from AWS Optimize CPUs docs) ──
+    $LicenseRates = @{
+        "Windows"        = 0.046
+        "SQLWeb"         = 0.063
+        "SQLStandard"    = 0.166
+        "SQLEnterprise"  = 0.421
+    }
+
+    # ── Pricing API filter values per license type ──
+    # Operation codes identify the exact license-included SKU
+    $LicenseFilterMap = @{
+        "Windows"        = @{ OS = "Windows"; SW = "NA";      Op = "RunInstances:0002" }
+        "SQLWeb"         = @{ OS = "Windows"; SW = "SQL Web"; Op = "RunInstances:0202" }
+        "SQLStandard"    = @{ OS = "Windows"; SW = "SQL Std"; Op = "RunInstances:0006" }
+        "SQLEnterprise"  = @{ OS = "Windows"; SW = "SQL Ent"; Op = "RunInstances:0102" }
+    }
+
+    # ── Minimum default vCPUs required to launch per license type ──
+    # Enterprise: 4 vCPU minimum on all families
+    # Standard: 4 vCPU minimum on T-series only
+    # Web/Windows: no restriction
+    $MinVcpuMap = @{
+        "Windows"        = 1
+        "SQLWeb"         = 1
+        "SQLStandard"    = 1
+        "SQLEnterprise"  = 4
+    }
+    $MinVcpuTseriesMap = @{
+        "Windows"        = 1
+        "SQLWeb"         = 1
+        "SQLStandard"    = 4
+        "SQLEnterprise"  = 4
+    }
+
+    # ── Expand license type shortcuts ──
+    $expandedLicenseTypes = @()
+    foreach ($lt in $LicenseType) {
+        switch ($lt) {
+            'All' { $expandedLicenseTypes += @('Windows', 'SQLWeb', 'SQLStandard', 'SQLEnterprise') }
+            'SQL' { $expandedLicenseTypes += @('SQLWeb', 'SQLStandard', 'SQLEnterprise') }
+            default { $expandedLicenseTypes += $lt }
+        }
+    }
+    # Preserve intended order: Windows first, then SQL Web → Standard → Enterprise
+    $licenseOrder = @('Windows', 'SQLWeb', 'SQLStandard', 'SQLEnterprise')
+    $expandedLicenseTypes = $licenseOrder | Where-Object { $_ -in $expandedLicenseTypes }
+
+    # Pricing API only works from us-east-1 or ap-south-1
+    $PricingRegion = "us-east-1"
+
+    $results = [System.Collections.Generic.List[PSObject]]::new()
+    $isFamilyQuery = $false
+
+    # ── Helper: query Pricing API for On-Demand hourly rate ──
+    # Uses regionCode filter (works for any region, no location name mapping needed).
+    # Filters on capacitystatus=Used, then takes the max non-zero price.
+    function Get-OnDemandPrice {
+        param(
+            [string]$InstanceTypeName,
+            [string]$OS,
+            [string]$PreInstalledSw,
+            [string]$Operation,
+            [string]$RegionCode,
+            [string]$PricingRgn
+        )
+
+        $filters = @(
+            @{ Type = "TERM_MATCH"; Field = "instanceType";    Value = $InstanceTypeName },
+            @{ Type = "TERM_MATCH"; Field = "regionCode";      Value = $RegionCode },
+            @{ Type = "TERM_MATCH"; Field = "operatingSystem";  Value = $OS },
+            @{ Type = "TERM_MATCH"; Field = "preInstalledSw";  Value = $PreInstalledSw },
+            @{ Type = "TERM_MATCH"; Field = "tenancy";         Value = "Shared" },
+            @{ Type = "TERM_MATCH"; Field = "operation";       Value = $Operation }
+        )
+
+        $raw = Get-PLSProduct -ServiceCode AmazonEC2 -Filter $filters -Region $PricingRgn -ErrorAction SilentlyContinue
+        $prices = @()
+
+        foreach ($jsonStr in $raw) {
+            $product = $jsonStr | ConvertFrom-Json
+
+            # Only consider "Used" capacity (skip "AllocatedCapacityReservation" etc.)
+            if ($product.product.attributes.capacitystatus -ne 'Used') { continue }
+
+            $onDemand = $product.terms.OnDemand
+            if (-not $onDemand) { continue }
+
+            $skuTerm = $onDemand.PSObject.Properties.Value | Select-Object -First 1
+            $usd = $skuTerm.priceDimensions.PSObject.Properties.Value.pricePerUnit.USD | Select-Object -First 1
+            if ($usd -and [decimal]$usd -gt 0) {
+                $prices += [decimal]$usd
+            }
+        }
+
+        if ($prices.Count -gt 0) {
+            return ($prices | Measure-Object -Maximum).Maximum
+        }
+        return $null
+    }
+}
+
+process {
+    # ── Expand family prefixes (e.g. "m8i" → all m8i.* sizes) ──
+    $expandedTypes = @()
+    foreach ($type in $InstanceType) {
+        if ($type -notmatch '\.' -or $type -match '[\*\?]') {
+            $isFamilyQuery = $true
+            $prefix = $type -replace '[\.\*\?]+$',''
+            Write-Verbose "Expanding family prefix '$prefix' ..."
+            try {
+                $filters = @(@{Name='instance-type'; Values="${prefix}*.*"})
+                $filters += @{Name='processor-info.supported-architecture'; Values='x86_64'}
+                $familyTypes = Get-EC2InstanceType -Filter $filters -Region $Region |
+                    Where-Object { $prefix.Length -le 1 -or $_.InstanceType.Value -match "^${prefix}[\.\-]" } |
+                    Select-Object -ExpandProperty InstanceType |
+                    Sort-Object { [regex]::Match($_, '\.(\d+)').Groups[1].Value -as [int] }
+                if ($familyTypes) {
+                    $expandedTypes += $familyTypes
+                } else {
+                    Write-Warning "No instance types found for family '$type' in $Region."
+                }
+            }
+            catch {
+                Write-Warning "Could not expand family '$type' in $Region : $_"
+            }
+        } else {
+            $expandedTypes += $type
+        }
+    }
+
+    # ── Filter by -Size if specified ──
+    if ($Size) {
+        $expandedTypes = $expandedTypes | Where-Object { $_ -match "\.$Size$" }
+        if ($expandedTypes.Count -eq 0) {
+            Write-Warning "No instance types match size '$Size'."
+            return
+        }
+    }
+
+    foreach ($type in $expandedTypes) {
+        Write-Verbose "Processing $type ..."
+
+        # Flag burstable (T-series) instances — Optimize CPUs billing doesn't apply
+        $isBurstable = $type -match '^t\d'
+
+        # ── 1. Get CPU info from EC2 DescribeInstanceTypes ──
+        try {
+            $info = Get-EC2InstanceType -InstanceType $type -Region $Region
+        }
+        catch {
+            Write-Warning "Could not describe instance type '$type' in $Region : $_"
+            continue
+        }
+
+        $defaultVcpus       = $info.VCpuInfo.DefaultVCpus
+        $defaultCores       = $info.VCpuInfo.DefaultCores
+        $defaultThreads     = $info.VCpuInfo.DefaultThreadsPerCore
+        $validThreads       = $info.VCpuInfo.ValidThreadsPerCore
+        $memoryMiB          = $info.MemoryInfo.SizeInMiB
+        $isMetal            = $info.BareMetal
+
+        # Check if ThreadsPerCore = 1 is supported
+        if ($validThreads -and $validThreads -notcontains 1) {
+            Write-Warning "$type does not support ThreadsPerCore = 1. Skipping."
+            continue
+        }
+
+        # Active vCPUs when ThreadsPerCore = 1
+        $optimizedVcpus = $defaultCores
+
+        # ── 2. Get the Amazon Linux base rate (same for all license types) ──
+        $linuxRate = $null
+        if (-not $isBurstable -and -not $isMetal) {
+            $linuxRate = Get-OnDemandPrice -InstanceTypeName $type `
+                                            -OS "Linux" `
+                                            -PreInstalledSw "NA" `
+                                            -Operation "RunInstances" `
+                                            -RegionCode $Region `
+                                            -PricingRgn $PricingRegion
+            if ($null -eq $linuxRate) {
+                Write-Warning "No Linux pricing found for $type in $Region. Skipping."
+                continue
+            }
+        }
+
+        # ── 3. Loop over each license type ──
+        foreach ($licType in $expandedLicenseTypes) {
+            $PerVcpuRate     = $LicenseRates[$licType]
+            $WinFilter       = $LicenseFilterMap[$licType]
+            $MinVcpus        = $MinVcpuMap[$licType]
+            $MinVcpusTseries = $MinVcpuTseriesMap[$licType]
+
+            $effectiveMinVcpus = if ($isBurstable) { $MinVcpusTseries } else { $MinVcpus }
+            $isTooSmall = $defaultVcpus -lt $effectiveMinVcpus
+
+            if ($isTooSmall) {
+                $tooSmallNotes = @('4')
+                if ($isBurstable) { $tooSmallNotes += '3' }
+                if ($isMetal) { $tooSmallNotes += '5' }
+                $results.Add([PSCustomObject]@{
+                    InstanceType = $type; MemoryGiB = [math]::Round($memoryMiB / 1024, 1)
+                    DefaultVCpus = $defaultVcpus; NoSMTvCpus = $defaultCores; DefaultTPC = $defaultThreads
+                    LicenseType = $licType; DefaultCost = $null; NoSMTCost = $null
+                    Difference = $null; SavingsPct = $null; Hours = $HoursNum
+                    IsBurstable = $isBurstable; IsTooSmall = $true
+                    Notes = ($tooSmallNotes | Sort-Object) -join ','
+                })
+                continue
+            }
+
+            $billableVcpus = [math]::Max($optimizedVcpus, $effectiveMinVcpus)
+            $hasMinBilling = $optimizedVcpus -lt $effectiveMinVcpus -and $effectiveMinVcpus -gt 1
+
+            # Get the standard Windows/SQL combined On-Demand rate
+            $windowsRate = Get-OnDemandPrice -InstanceTypeName $type `
+                                              -OS $WinFilter.OS `
+                                              -PreInstalledSw $WinFilter.SW `
+                                              -Operation $WinFilter.Op `
+                                              -RegionCode $Region `
+                                              -PricingRgn $PricingRegion
+
+            if ($null -eq $windowsRate) {
+                Write-Warning "No $licType pricing found for $type in $Region. Skipping."
+                continue
+            }
+
+            $standardHourly = $windowsRate
+            $standardTotal  = $standardHourly * $HoursNum
+
+            # Burstable or .metal: show Default cost only, NoSMT not applicable
+            if ($isBurstable -or $isMetal) {
+                $note = if ($isBurstable) { '3' } else { '5' }
+                $results.Add([PSCustomObject]@{
+                    InstanceType = $type; MemoryGiB = [math]::Round($memoryMiB / 1024, 1)
+                    DefaultVCpus = $defaultVcpus; NoSMTvCpus = $defaultCores; DefaultTPC = $defaultThreads
+                    LicenseType = $licType; DefaultCost = [math]::Round($standardTotal, 2)
+                    NoSMTCost = $null; Difference = $null; SavingsPct = $null
+                    Hours = $HoursNum; IsBurstable = $isBurstable; IsTooSmall = $false; Notes = $note
+                })
+                continue
+            }
+
+            # ── 4. Calculate costs ──
+            $licenseFeeHourly = $billableVcpus * $PerVcpuRate
+            $optimizedHourly  = $linuxRate + $licenseFeeHourly
+            $optimizedTotal   = $optimizedHourly * $HoursNum
+
+            $diffTotal  = $optimizedTotal - $standardTotal
+            $savingsPct = if ($standardHourly -gt 0) { (($standardHourly - $optimizedHourly) / $standardHourly) * 100 } else { 0 }
+
+            # No SMT to disable — force zero difference
+            if ($defaultVcpus -eq $optimizedVcpus) {
+                $optimizedTotal = $standardTotal
+                $diffTotal  = 0
+                $savingsPct = 0
+            }
+
+            $results.Add([PSCustomObject]@{
+                InstanceType = $type; MemoryGiB = [math]::Round($memoryMiB / 1024, 1)
+                DefaultVCpus = $defaultVcpus; NoSMTvCpus = $optimizedVcpus
+                DefaultTPC = $defaultThreads; LicenseType = $licType
+                DefaultCost = [math]::Round($standardTotal, 2)
+                NoSMTCost = [math]::Round($optimizedTotal, 2)
+                Difference = [math]::Round($diffTotal, 2)
+                SavingsPct = [math]::Round($savingsPct, 1)
+                Hours = $HoursNum; IsBurstable = $false; IsTooSmall = $false
+                Notes = $(
+                    $n = @()
+                    if ($defaultThreads -eq 1) { $n += '1' }
+                    if ($hasMinBilling) { $n += '2' }
+                    if ($n.Count -gt 0) { $n -join ',' } else { '' }
+                )
+            })
+            Write-Verbose ("{0}/{1}: Standard={2:C4}/hr  Optimized={3:C4}/hr  Savings={4:P1}" -f $type, $licType, $standardHourly, $optimizedHourly, ($savingsPct / 100))
+        }
+    }
+}
+
+end {
+    if ($results.Count -eq 0) {
+        Write-Warning "No results to display."
+        return
+    }
+
+    # Sort results — default to NoSMTvCpus ascending for family queries
+    $effectiveSortBy = $SortBy
+    $propMap = @{
+        'SavingsPct'   = 'SavingsPct'
+        'Savings'      = 'Difference'
+        'Default'      = 'DefaultCost'
+        'TPC1'         = 'NoSMTCost'
+        'Cores'        = 'NoSMTvCpus'
+        'vCPUs'        = 'DefaultVCpus'
+        'InstanceType' = 'InstanceType'
+    }
+    $ascendingKeys = @('InstanceType', 'Cores', 'vCPUs')
+
+    $isMultiLicense = $expandedLicenseTypes.Count -gt 1
+
+    if ($isFamilyQuery -and -not $PSBoundParameters.ContainsKey('SortBy')) {
+        # Family query: sort by family prefix, vCPU count, then license order
+        $sorted = $results | Sort-Object { ($_.InstanceType -split '\.')[0] }, DefaultVCpus, { $licenseOrder.IndexOf($_.LicenseType) }
+    } elseif ($isMultiLicense -and -not $PSBoundParameters.ContainsKey('SortBy')) {
+        # Multi-license: sort by instance type, then license order
+        $sorted = $results | Sort-Object InstanceType, { $licenseOrder.IndexOf($_.LicenseType) }
+    } else {
+        $sortExpressions = foreach ($key in $effectiveSortBy) {
+            $prop = $propMap[$key]
+            $desc = $key -notin $ascendingKeys
+            @{ Expression = $prop; Descending = $desc }
+        }
+        $sorted = $results | Sort-Object $sortExpressions
+    }
+
+    # Money format: show cents for hourly, whole dollars otherwise
+    if ($HoursNum -eq 1) {
+        $fmtDefault = { if ($null -eq $_.DefaultCost) { '--' } else { '${0:N2}' -f $_.DefaultCost } }
+        $fmtNoSMT   = { if ($null -eq $_.NoSMTCost) { '--' } else { '${0:N2}' -f $_.NoSMTCost } }
+        $fmtDiff    = { if ($null -eq $_.Difference) { '--' } elseif ($_.Difference -lt 0) { '-${0:N2}' -f [math]::Abs($_.Difference) } elseif ($_.Difference -eq 0) { '$0.00' } else { '${0:N2}' -f $_.Difference } }
+    } else {
+        $fmtDefault = { if ($null -eq $_.DefaultCost) { '--' } else { '${0:N0}' -f $_.DefaultCost } }
+        $fmtNoSMT   = { if ($null -eq $_.NoSMTCost) { '--' } else { '${0:N0}' -f $_.NoSMTCost } }
+        $fmtDiff    = { if ($null -eq $_.Difference) { '--' } elseif ($_.Difference -lt 0) { '-${0:N0}' -f [math]::Abs($_.Difference) } elseif ($_.Difference -eq 0) { '$0' } else { '${0:N0}' -f $_.Difference } }
+    }
+
+    # Console output
+    $shortRegion = $Region -replace 'us-east-','use' -replace 'us-west-','usw' -replace 'eu-west-','euw' -replace 'eu-central-','euc' -replace 'eu-north-','eun' -replace 'eu-south-','eus' -replace 'ap-northeast-','apne' -replace 'ap-southeast-','apse' -replace 'ap-south-','aps' -replace 'ca-central-','cac' -replace 'sa-east-','sae' -replace 'me-south-','mes' -replace 'af-south-','afs'
+    $cols = @(
+        @{N='Region'; E={$shortRegion}},
+        'InstanceType'
+    )
+    $cols += @(
+        @{N='LicenseType';   E={$_.LicenseType}},
+        @{N='Cores';   E={ if ($null -eq $_.NoSMTvCpus) { '--' } else { $_.NoSMTvCpus } }; Align='Right'},
+        @{N='TPC';    E={$_.DefaultTPC}; Align='Right'},
+        @{N='vCPUs';  E={$_.DefaultVCpus}; Align='Right'}
+    )
+    if ($Memory) { $cols += @{N='MemoryGiB'; E={[int]$_.MemoryGiB}; Align='Right'} }
+    $cols += @(
+        @{N='Hours';         E={$_.Hours};         Align='Right'},
+        @{N=' Default $';   E=$fmtDefault;        Align='Right'},
+        @{N='  TPC=1 $';   E=$fmtNoSMT;         Align='Right'},
+        @{N=' Savings $';  E=$fmtDiff;           Align='Right'},
+        @{N='  Savings %';   E={ if ($null -eq $_.SavingsPct) { '--' } else { '{0:N1}%' -f $_.SavingsPct } }; Align='Right'},
+        @{N='Note'; E={$_.Notes}}
+    )
+    $sorted | Format-Table -Property $cols
+
+    # Footnotes — only show notes that appear in the results
+    $allNotes = ($results | Where-Object { $_.Notes } | ForEach-Object { $_.Notes -split ',' }) | Sort-Object -Unique
+    $noteDescriptions = @{
+        '1' = 'Instance type defaults to TPC=1 — no SMT to disable, savings = 0%'
+        '2' = 'SQL Server Standard/Enterprise minimum 4-vCPU billing applies'
+        '3' = 'T-series (burstable) — Optimize CPUs not applicable'
+        '4' = 'Instance too small for selected SQL edition'
+        '5' = '.metal — Optimize CPUs not applicable'
+    }
+    if ($allNotes.Count -gt 0) {
+        foreach ($n in $allNotes) {
+            if ($noteDescriptions.ContainsKey($n)) {
+                Write-Host "  $n = $($noteDescriptions[$n])" -ForegroundColor Yellow
+            }
+        }
+    }
+
+    # CSV export
+    if ($OutputCsv) {
+        $sorted | Export-Csv -Path $OutputCsv -NoTypeInformation -Force
+        Write-Host "Results exported to $OutputCsv"
+    }
+
+    # Pricing footnotes
+    Write-Host ""
+    Write-Host "Default $ is based on On-Demand pricing. " -ForegroundColor Cyan
+    Write-Host "Savings $ is the same regardless of pricing model (On-Demand, Savings Plans, etc.) since" -ForegroundColor Cyan
+    Write-Host "   per-vCPU license rates are fixed." -ForegroundColor Cyan
+    Write-Host "Note: Reserved Instances may not apply discounts with Optimize CPUs — use Savings Plans instead." -ForegroundColor Cyan
+
+    if ($MyInvocation.PipelinePosition -lt $MyInvocation.PipelineLength) {
+        $sorted
+    }
+}

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/SetThreadsPerCore_SSM/README.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/SetThreadsPerCore_SSM/README.md
@@ -157,5 +157,5 @@ When an instance is skipped, the automation ends with a descriptive step name:
 
 ## Author
 
-Craig Cooley (coolcrai@amazon.com) — May 2026
+Craig Cooley — May 2026
 Built with [Kiro](https://kiro.dev) IDE + Claude Opus 4.6

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/SetThreadsPerCore_SSM/README.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/SetThreadsPerCore_SSM/README.md
@@ -1,0 +1,161 @@
+# Set-ThreadsPerCore — SSM Automation Document
+
+An AWS Systems Manager Automation document that sets ThreadsPerCore=1 on EC2 instances to disable SMT (Simultaneous Multithreading), reducing Windows and SQL Server license-included costs.
+
+## What it does
+
+For each target instance, the document:
+
+1. Checks if the instance is bare metal or doesn't support the requested ThreadsPerCore (skips if so)
+2. Checks if ThreadsPerCore already matches the requested value (skips if so)
+3. For stopped instances: modifies CPU options directly
+4. For running instances (when allowed): stops the instance, modifies CPU options, restarts it
+5. Sets CoreCount based on the `CoreCount` parameter (`default` = instance type's full core count, `current` = keep existing)
+
+## Safety checks
+
+The document includes several pre-flight checks that **fail safe** — if an API call errors
+(missing permissions, throttling), the automation aborts rather than proceeding with the modification.
+
+| Check | Default | Behavior |
+|---|---|---|
+| Bare metal | always skip | Bare metal instances don't support Optimize CPUs |
+| Platform mismatch | skip | Only modifies instances matching the `Platform` parameter. Set `Platform=All` to override |
+| Unsupported TPC | always skip | Instance types that don't support the requested ThreadsPerCore |
+| Auto Scaling group | always skip | Instances in an ASG are always skipped. API errors abort (fail-safe). |
+| Instance store | skip | Ephemeral data lost on stop. Set `SkipInstanceStore=no` to override |
+| Non-EIP public IP | skip | Public IP changes on stop/start. API errors abort (fail-safe). Set `SkipPublicIP=no` to override |
+| Running instances | skip | Set `StopStartedInstances=yes` to allow stop/modify/restart |
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `InstanceId` | *(required)* | EC2 instance ID (use SSM targeting for multiple instances) |
+| `ThreadsPerCore` | `1` | Threads per core to set (`1` to disable SMT, `2` to re-enable) |
+| `CoreCount` | `current` | Core count: `default` (instance type's full core count) or `current` (keep existing) |
+| `StopStartedInstances` | `no` | Allow stopping running instances to modify CPU options |
+| `Platform` | `Windows` | Platform filter: `Windows`, `Linux`, or `All` |
+| `SkipPublicIP` | `yes` | Skip running instances with non-EIP public IPs |
+| `SkipInstanceStore` | `yes` | Skip running instances on types with instance store |
+
+## Usage
+
+### Install the document
+
+```powershell
+New-SSMDocument `
+    -Name "Set-ThreadsPerCore" `
+    -DocumentType "Automation" `
+    -Content (Get-Content -Raw Set-ThreadsPerCore.yaml) `
+    -DocumentFormat YAML `
+    -Region us-east-1
+```
+
+### Run on a single stopped instance
+
+```powershell
+Start-SSMAutomationExecution `
+    -DocumentName "Set-ThreadsPerCore" `
+    -Parameter @{InstanceId=@("i-0abc123def456789a")} `
+    -Region us-east-1
+```
+
+### Run on a single running instance (stop, modify, restart)
+
+```powershell
+Start-SSMAutomationExecution `
+    -DocumentName "Set-ThreadsPerCore" `
+    -Parameter @{InstanceId=@("i-0abc123def456789a"); StopStartedInstances=@("yes")} `
+    -Region us-east-1
+```
+
+### Re-enable SMT (set ThreadsPerCore back to 2)
+
+```powershell
+Start-SSMAutomationExecution `
+    -DocumentName "Set-ThreadsPerCore" `
+    -Parameter @{InstanceId=@("i-0abc123def456789a"); ThreadsPerCore=@("2")} `
+    -Region us-east-1
+```
+
+### Run on multiple instances using tags
+
+```powershell
+Start-SSMAutomationExecution `
+    -DocumentName "Set-ThreadsPerCore" `
+    -Target @{Key="tag:Env"; Values=@("Production")} `
+    -TargetParameterName "InstanceId" `
+    -MaxConcurrency "5" `
+    -MaxError "1" `
+    -Region us-east-1
+```
+
+### Run on instances with TPC=2 (pre-filtered)
+
+```powershell
+$tpc2 = (Get-EC2Instance -Region us-east-1 -Filter @{Name='instance-state-name'; Values=@('running','stopped')}).Instances |
+    Where-Object { $_.CpuOptions.ThreadsPerCore -eq 2 } |
+    Select-Object -ExpandProperty InstanceId
+
+Start-SSMAutomationExecution `
+    -DocumentName "Set-ThreadsPerCore" `
+    -Target @{Key="ParameterValues"; Values=$tpc2} `
+    -TargetParameterName "InstanceId" `
+    -Parameter @{StopStartedInstances=@("yes")} `
+    -MaxConcurrency "5" `
+    -MaxError "1" `
+    -Region us-east-1
+```
+
+### Run from the SSM Console
+
+1. Open [Systems Manager > Automation](https://console.aws.amazon.com/systems-manager/automation)
+2. Click "Execute automation"
+3. Search for "Set-ThreadsPerCore"
+4. Choose "Simple execution" for a single instance, or "Rate control" for multiple
+5. Fill in parameters and execute
+
+## Permissions required
+
+The caller (IAM user/role) needs:
+
+- `ec2:DescribeInstances`
+- `ec2:DescribeInstanceTypes`
+- `ec2:DescribeNetworkInterfaces`
+- `ec2:ModifyInstanceCpuOptions`
+- `ec2:StopInstances` (if StopStartedInstances=yes)
+- `ec2:StartInstances` (if StopStartedInstances=yes)
+- `autoscaling:DescribeAutoScalingInstances`
+- `ssm:StartAutomationExecution`
+
+No IAM assume role is used — the document runs with the caller's permissions.
+
+## Skip reasons
+
+When an instance is skipped, the automation ends with a descriptive step name:
+
+| Step | Reason |
+|---|---|
+| `AlreadyConfigured` | ThreadsPerCore already matches the requested value |
+| `SkippedBareMetal` | Instance is bare metal (Optimize CPUs not supported) |
+| `SkippedNonWindows` | Instance platform doesn't match the `Platform` parameter |
+| `SkippedUnsupportedTPC` | Requested ThreadsPerCore not supported by the instance type |
+| `SkippedRunning` | Instance is running and StopStartedInstances=no |
+| `SkippedASG` | Instance is in an Auto Scaling group |
+| `SkippedPublicIP` | Instance has a non-EIP public IP |
+| `SkippedInstanceStore` | Instance type has instance store volumes |
+| `SkippedUnsupportedState` | Instance is not running or stopped |
+
+## Notes
+
+- CPU options can only be modified on stopped instances — the document handles the stop/start cycle.
+- CoreCount is always set to the instance type's default (all physical cores). Only ThreadsPerCore is changed.
+- Instances already configured with ThreadsPerCore=1 are detected and skipped immediately.
+- Use `ThreadsPerCore=2` to re-enable SMT if needed.
+- SSM Automation is regional — the document must be installed in each region where you want to target instances. Use `-Region` to specify the target region when running from the command line.
+
+## Author
+
+Craig Cooley (coolcrai@amazon.com) — May 2026
+Built with [Kiro](https://kiro.dev) IDE + Claude Opus 4.6

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/SetThreadsPerCore_SSM/Set-ThreadsPerCore.yaml
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/Scripts/SetThreadsPerCore_SSM/Set-ThreadsPerCore.yaml
@@ -1,0 +1,406 @@
+description: |
+  Sets ThreadsPerCore on an EC2 instance to disable SMT (Simultaneous Multithreading).
+  This can reduce Windows and SQL Server license-included costs by reducing the active vCPU count.
+
+  The document modifies the instance's CPU options to set ThreadsPerCore=1 while keeping
+  all physical cores active. The instance must be stopped to modify CPU options.
+
+  For running instances, set StopStartedInstances to 'yes' to automatically stop,
+  modify, and restart the instance.
+
+  Author: Craig Cooley (coolcrai@amazon.com)
+  Built with: Kiro IDE + Claude Opus 4.6
+  Date: May 2026
+
+schemaVersion: '0.3'
+assumeRole: ''
+parameters:
+  InstanceId:
+    type: String
+    description: The EC2 instance ID to modify.
+  ThreadsPerCore:
+    type: Integer
+    default: 1
+    description: Threads per core to set. Use 1 to disable SMT.
+    allowedValues:
+      - 1
+      - 2
+  StopStartedInstances:
+    type: String
+    default: 'no'
+    description: >-
+      If 'yes', running instances will be stopped, modified, and restarted.
+      If 'no', running instances are skipped.
+    allowedValues:
+      - 'yes'
+      - 'no'
+  SkipPublicIP:
+    type: String
+    default: 'yes'
+    description: >-
+      If 'yes', skip running instances that have a non-EIP public IP address
+      (the IP will change on stop/start).
+    allowedValues:
+      - 'yes'
+      - 'no'
+  Platform:
+    type: String
+    default: 'Windows'
+    description: >-
+      Platform filter: 'Windows' only modifies Windows instances, 'Linux' only Linux,
+      'All' modifies any platform.
+    allowedValues:
+      - 'Windows'
+      - 'Linux'
+      - 'All'
+  SkipInstanceStore:
+    type: String
+    default: 'yes'
+    description: >-
+      If 'yes', skip running instances on instance types with instance store
+      (ephemeral data is lost on stop).
+    allowedValues:
+      - 'yes'
+      - 'no'
+  CoreCount:
+    type: String
+    default: 'current'
+    description: >-
+      Core count to set. 'default' uses the instance type's default core count
+      (all physical cores). 'current' keeps the instance's current core count.
+    allowedValues:
+      - 'default'
+      - 'current'
+
+mainSteps:
+  - name: GetInstanceDetails
+    action: aws:executeAwsApi
+    inputs:
+      Service: ec2
+      Api: DescribeInstances
+      InstanceIds:
+        - '{{ InstanceId }}'
+    outputs:
+      - Name: InstanceState
+        Selector: $.Reservations[0].Instances[0].State.Name
+        Type: String
+      - Name: InstanceType
+        Selector: $.Reservations[0].Instances[0].InstanceType
+        Type: String
+      - Name: CurrentCoreCount
+        Selector: $.Reservations[0].Instances[0].CpuOptions.CoreCount
+        Type: Integer
+      - Name: CurrentThreadsPerCore
+        Selector: $.Reservations[0].Instances[0].CpuOptions.ThreadsPerCore
+        Type: Integer
+      - Name: Platform
+        Selector: $.Reservations[0].Instances[0].Platform
+        Type: String
+
+  - name: GetInstanceTypeInfo
+    action: aws:executeAwsApi
+    inputs:
+      Service: ec2
+      Api: DescribeInstanceTypes
+      InstanceTypes:
+        - '{{ GetInstanceDetails.InstanceType }}'
+    outputs:
+      - Name: DefaultCores
+        Selector: $.InstanceTypes[0].VCpuInfo.DefaultCores
+        Type: Integer
+      - Name: DefaultThreadsPerCore
+        Selector: $.InstanceTypes[0].VCpuInfo.DefaultThreadsPerCore
+        Type: Integer
+      - Name: InstanceStorageSupported
+        Selector: $.InstanceTypes[0].InstanceStorageSupported
+        Type: Boolean
+      - Name: BareMetal
+        Selector: $.InstanceTypes[0].BareMetal
+        Type: Boolean
+
+  - name: CheckBareMetal
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: SkippedBareMetal
+          Variable: '{{ GetInstanceTypeInfo.BareMetal }}'
+          BooleanEquals: true
+      Default: CheckPlatform
+
+  - name: SkippedBareMetal
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance is bare metal. Optimize CPUs is not supported. Skipping.
+
+  - name: CheckPlatform
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: CheckValidTPC
+          Variable: '{{ Platform }}'
+          StringEquals: 'All'
+        - NextStep: BranchPlatformWindows
+          Variable: '{{ Platform }}'
+          StringEquals: 'Windows'
+        - NextStep: BranchPlatformLinux
+          Variable: '{{ Platform }}'
+          StringEquals: 'Linux'
+      Default: SkippedNonWindows
+
+  - name: BranchPlatformWindows
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: CheckValidTPC
+          Variable: '{{ GetInstanceDetails.Platform }}'
+          StringEquals: windows
+      Default: SkippedNonWindows
+
+  - name: BranchPlatformLinux
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: SkippedNonWindows
+          Variable: '{{ GetInstanceDetails.Platform }}'
+          StringEquals: windows
+      Default: CheckValidTPC
+
+  - name: SkippedNonWindows
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance platform does not match the Platform parameter. Skipping.
+
+  - name: CheckValidTPC
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: CheckAlreadyConfigured
+          Variable: '{{ GetInstanceTypeInfo.DefaultThreadsPerCore }}'
+          NumericGreaterOrEquals: '{{ ThreadsPerCore }}'
+      Default: SkippedUnsupportedTPC
+
+  - name: SkippedUnsupportedTPC
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Requested ThreadsPerCore is not supported by this instance type. Skipping.
+
+  - name: CheckAlreadyConfigured
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: AlreadyConfigured
+          Variable: '{{ GetInstanceDetails.CurrentThreadsPerCore }}'
+          NumericEquals: '{{ ThreadsPerCore }}'
+      Default: CheckInstanceState
+
+  - name: AlreadyConfigured
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance already has the requested ThreadsPerCore. No action needed.
+
+  - name: CheckInstanceState
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: BranchCoreCount
+          Variable: '{{ GetInstanceDetails.InstanceState }}'
+          StringEquals: stopped
+        - NextStep: CheckStopStartedParam
+          Variable: '{{ GetInstanceDetails.InstanceState }}'
+          StringEquals: running
+      Default: SkippedUnsupportedState
+
+  - name: SkippedUnsupportedState
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance is in an unsupported state (not running or stopped). Skipping.
+
+  - name: CheckStopStartedParam
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: CheckASGMembership
+          Variable: '{{ StopStartedInstances }}'
+          StringEquals: 'yes'
+      Default: SkippedRunning
+
+  - name: SkippedRunning
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance is running and StopStartedInstances is 'no'. Skipping.
+
+  - name: CheckASGMembership
+    action: aws:executeAwsApi
+    inputs:
+      Service: autoscaling
+      Api: DescribeAutoScalingInstances
+      InstanceIds:
+        - '{{ InstanceId }}'
+    outputs:
+      - Name: ASGInstanceId
+        Selector: $.AutoScalingInstances[0].InstanceId
+        Type: String
+    description: >-
+      Check if instance is managed by an Auto Scaling group.
+      If this API call fails (permissions, throttling), the automation aborts (fail-safe).
+      If the instance is not in an ASG, the selector returns empty string.
+
+  - name: BranchASGResult
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: SkippedASG
+          Variable: '{{ CheckASGMembership.ASGInstanceId }}'
+          StringEquals: '{{ InstanceId }}'
+      Default: CheckInstanceStoreParam
+
+  - name: SkippedASG
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance is in an Auto Scaling group. Skipping.
+
+  - name: CheckInstanceStoreParam
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: BranchInstanceStore
+          Variable: '{{ SkipInstanceStore }}'
+          StringEquals: 'yes'
+      Default: CheckPublicIP
+
+  - name: BranchInstanceStore
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: SkippedInstanceStore
+          Variable: '{{ GetInstanceTypeInfo.InstanceStorageSupported }}'
+          BooleanEquals: true
+      Default: CheckPublicIP
+
+  - name: SkippedInstanceStore
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance type has instance store and SkipInstanceStore is 'yes'. Skipping.
+
+  - name: CheckPublicIP
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: VerifyPublicIP
+          Variable: '{{ SkipPublicIP }}'
+          StringEquals: 'yes'
+      Default: StopInstance
+
+  - name: VerifyPublicIP
+    action: aws:executeAwsApi
+    inputs:
+      Service: ec2
+      Api: DescribeNetworkInterfaces
+      Filters:
+        - Name: attachment.instance-id
+          Values:
+            - '{{ InstanceId }}'
+    outputs:
+      - Name: IpOwnerId
+        Selector: $.NetworkInterfaces[0].Association.IpOwnerId
+        Type: String
+    description: >-
+      Check who owns the public IP on the primary ENI.
+      'amazon' = auto-assigned (will change on stop/start).
+      Account ID = EIP (safe). Empty = no public IP (safe).
+
+  - name: BranchPublicIPOwner
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: SkippedPublicIP
+          Variable: '{{ VerifyPublicIP.IpOwnerId }}'
+          StringEquals: amazon
+      Default: StopInstance
+
+  - name: SkippedPublicIP
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance has a non-EIP public IP and SkipPublicIP is 'yes'. Skipping.
+
+  - name: StopInstance
+    action: aws:changeInstanceState
+    inputs:
+      InstanceIds:
+        - '{{ InstanceId }}'
+      DesiredState: stopped
+    description: Stopping the running instance to modify CPU options.
+
+  - name: BranchCoreCount
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: ModifyCpuOptionsCurrent
+          Variable: '{{ CoreCount }}'
+          StringEquals: 'current'
+      Default: ModifyCpuOptionsDefault
+
+  - name: ModifyCpuOptionsDefault
+    action: aws:executeAwsApi
+    inputs:
+      Service: ec2
+      Api: ModifyInstanceCpuOptions
+      InstanceId: '{{ InstanceId }}'
+      CoreCount: '{{ GetInstanceTypeInfo.DefaultCores }}'
+      ThreadsPerCore: '{{ ThreadsPerCore }}'
+    description: Setting ThreadsPerCore with instance type default cores.
+    nextStep: CheckShouldRestart
+
+  - name: ModifyCpuOptionsCurrent
+    action: aws:executeAwsApi
+    inputs:
+      Service: ec2
+      Api: ModifyInstanceCpuOptions
+      InstanceId: '{{ InstanceId }}'
+      CoreCount: '{{ GetInstanceDetails.CurrentCoreCount }}'
+      ThreadsPerCore: '{{ ThreadsPerCore }}'
+    description: Setting ThreadsPerCore with current core count preserved.
+    nextStep: CheckShouldRestart
+
+  - name: CheckShouldRestart
+    action: aws:branch
+    inputs:
+      Choices:
+        - NextStep: StartInstance
+          Variable: '{{ GetInstanceDetails.InstanceState }}'
+          StringEquals: running
+      Default: CompleteStopped
+
+  - name: StartInstance
+    action: aws:changeInstanceState
+    inputs:
+      InstanceIds:
+        - '{{ InstanceId }}'
+      DesiredState: running
+    description: Restarting the instance after CPU modification.
+    isEnd: true
+
+  - name: CompleteStopped
+    action: aws:sleep
+    inputs:
+      Duration: PT0S
+    isEnd: true
+    description: Instance was already stopped. CPU options modified. Not restarting.

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -22,7 +22,7 @@ Setting `ThreadsPerCore = 1`:
 The scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across instance types by querying the AWS Pricing API and comparing License Included costs with and without hyperthreading.
 
 | Script | Description |
-|--------|-------------|
+|--------|-------------
 | `Show-OptimizedCpuCost.ps1` | Shows per-instance cost savings when setting [ThreadsPerCore](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CpuOptionsRequest.html)=1 |
 | `Show-AccountCpuOptimization.ps1` | Scans instances in your account and shows optimization opportunities |
 | `Set-ThreadsPerCore.yaml` | SSM Automation document to set [ThreadsPerCore](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CpuOptionsRequest.html) on existing instances |
@@ -55,3 +55,4 @@ This launches with 8 cores × 1 thread = 8 vCPUs instead of the default 8 cores 
 ## Author
 
 Craig Cooley (coolcrai@) — Built with Kiro IDE
+description: Reduce Microsoft license included costs on EC2 by adjusting ThreadsPerCore settings

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -50,9 +50,7 @@ This launches with 8 cores × 1 thread = 8 vCPUs instead of the default 8 cores 
 
 - **EC2 Windows** — Windows Server License Included instances
 - **SQL Server on EC2** — SQL Server License Included instances 
-- **RDS for SQL Server** — Latest RDS instance have `ThreadsPerCore = 1` by default
+- **RDS for SQL Server** — Latest RDS instance have `ThreadsPerCore = 1` set by default
   
 ## Author
-
 Craig Cooley (coolcrai@) — Built with Kiro IDE
-description: Reduce Microsoft license included costs on EC2 by adjusting ThreadsPerCore settings

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -23,9 +23,9 @@ The scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across 
 
 | Script | Description |
 |--------|-------------|
-| `Show-OptimizedCpuCost.ps1` | Shows per-instance cost savings when disabling hyperthreading |
+| `Show-OptimizedCpuCost.ps1` | Shows per-instance cost savings when setting [ThreadsPerCore](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CpuOptionsRequest.html)=1 |
 | `Show-AccountCpuOptimization.ps1` | Scans instances in your account and shows optimization opportunities |
-| `Set-ThreadsPerCore.yaml` | SSM Automation document to set ThreadsPerCore on existing instances |
+| `Set-ThreadsPerCore.yaml` | SSM Automation document to set [ThreadsPerCore](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CpuOptionsRequest.html) on existing instances |
 
 ### Requirements
 

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: Optimize CPU Costs for Windows Licensing
-description: Reduce Microsoft license included costs on EC2 by adjusting [ThreadsPerCore](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CpuOptionsRequest.html) settings
+description: Reduce Microsoft license included costs on EC2 by adjusting ThreadsPerCore settings
 ---
 
 # Optimize CPU Costs for Windows Licensing

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: Optimize CPU Costs for Windows Licensing
-description: Reduce Microsoft license included costs on EC2 by adjusting ThreadsPerCore settings
+description: Reduce Microsoft license included costs on EC2 by adjusting [ThreadsPerCore](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CpuOptionsRequest.html) settings
 ---
 
 # Optimize CPU Costs for Windows Licensing
@@ -10,10 +10,10 @@ Reduce Microsoft licensing costs on Amazon EC2 and SQL Server instances by disab
 
 ## Why This Matters
 
-Windows Server and SQL Server are licensed **per active vCPU** on AWS. By default, most EC2 instance types have 2 VCPUs per physical core (hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
+Windows Server and SQL Server are licensed **per active vCPU** on AWS. By default, most EC2 instance types have 2 vCPUs per physical core (hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
 
 Setting `ThreadsPerCore = 1`:
-- **Halves your Windows/SQL licensing cost** (License Included pricing is per active vCPU)
+- **Halves your Windows/SQL licensing cost** (AWS License Included pricing is per active vCPU)
 - Does not affect the compute cost — only the license component
 - see [Optimize CPUs for License-Included instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html) for details
 
@@ -33,12 +33,6 @@ The scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across 
 - AWS.Tools.EC2 and AWS.Tools.Pricing modules (pre-installed in AWS CloudShell)
 - AWS credentials with EC2 and Pricing API permissions
 
-### Quick Start (AWS CloudShell)
-
-```powershell
-pwsh
-.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.4xlarge -Region us-east-1
-```
 
 ## How ThreadsPerCore Works
 
@@ -57,6 +51,7 @@ This launches with 8 cores × 1 thread = 8 vCPUs instead of the default 8 cores 
 - **EC2 Windows** — Windows Server License Included instances
 - **SQL Server on EC2** — SQL Server License Included instances 
 - **RDS for SQL Server** — Latest RDS instance have `ThreadsPerCore = 1` by default
+  
 ## Author
 
 Craig Cooley (coolcrai@) — Built with Kiro IDE

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -19,7 +19,7 @@ Setting `ThreadsPerCore = 1`:
 
 ## Scripts
 
-The 2 PowerShell scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across instance types by querying the AWS Pricing API and comparing License costs with and without hyperthreading.  The SSM Automation (Set-ThreadsPerCore.yaml) can be used to configure `ThreadsPerCore = 1` on multiple instances at once.  Individual instances can be confugired from the AWS console or Command Line.  
+The 2 PowerShell scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across instance types by querying the AWS Pricing API and comparing License costs with and without hyperthreading.  The SSM Automation (Set-ThreadsPerCore.yaml) can be used to configure `ThreadsPerCore = 1` on multiple instances at once.  Individual instances can be configured from the AWS console or Command Line.  
 
 | Script | Description |
 |--------|-------------

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -10,7 +10,7 @@ Reduce Microsoft licensing costs on Amazon EC2 and SQL Server instances by disab
 
 ## Why This Matters
 
-Windows Server and SQL Server are licensed **per active vCPU** on AWS. By default, most EC2 instance types have 2 vCPUs per physical core (hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
+Windows Server and SQL Server are licensed **per active vCPU** on AWS. By default, most EC2 instance types have 2 vCPUs per physical core (also known as hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
 
 Setting `ThreadsPerCore = 1`:
 - **Halves your Windows/SQL licensing cost** (AWS License Included pricing is per active vCPU)
@@ -19,7 +19,7 @@ Setting `ThreadsPerCore = 1`:
 
 ## Scripts
 
-The scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across instance types by querying the AWS Pricing API and comparing License Included costs with and without hyperthreading.
+The 2 PowerShell scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across instance types by querying the AWS Pricing API and comparing License costs with and without hyperthreading.  The SSM Automation (Set-ThreadsPerCore.yaml) can be used to configure `ThreadsPerCore = 1` on multiple instances at once.  Individual instances can be confugired from the AWS console or Command Line.  
 
 | Script | Description |
 |--------|-------------

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 4
+title: Optimize CPU Costs for Windows Licensing
+description: Reduce Microsoft per-core licensing costs on EC2 by adjusting ThreadsPerCore settings
+---
+
+# Optimize CPU Costs for Windows Licensing
+
+Reduce Microsoft per-core licensing costs on Amazon EC2 and SQL Server instances by disabling hyperthreading (setting ThreadsPerCore = 1). This PowerShell script calculates potential savings and helps you understand the cost impact across instance types.
+
+## Why This Matters
+
+Windows Server and SQL Server are licensed **per physical core** on AWS. By default, most EC2 instance types enable 2 threads per core (hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
+
+Setting `ThreadsPerCore = 1` at launch:
+- **Halves your Windows/SQL licensing cost** (License Included pricing is per-vCPU)
+- May be appropriate for memory-bound or I/O-bound workloads
+- Does not affect the on-demand compute cost — only the license component
+
+## Script
+
+The `Show-OptimizeCPUCosts` script demonstrates cost savings across instance types by querying the AWS Pricing API and comparing License Included costs with and without hyperthreading.
+
+**Repository:** [gitlab.aws.dev/coolcrai/Show-OptimizeCPUCosts](https://gitlab.aws.dev/coolcrai/Show-OptimizeCPUCosts)
+
+### Requirements
+
+- PowerShell 7+ (pre-installed in AWS CloudShell)
+- AWS.Tools.EC2 and AWS.Tools.Pricing modules (pre-installed in AWS CloudShell)
+- AWS credentials with EC2 and Pricing API permissions
+
+### Quick Start (AWS CloudShell)
+
+```powershell
+pwsh
+.\Show-OptimizeCPUCosts.ps1 -InstanceType m7a.4xlarge -Region us-east-1
+```
+
+## How ThreadsPerCore Works
+
+When launching an EC2 instance, you can specify CPU options:
+
+```powershell
+New-EC2Instance -InstanceType m7a.4xlarge `
+    -CpuOption_ThreadsPerCore 1 `
+    -CpuOption_CoreCount 8
+```
+
+This launches with 8 cores × 1 thread = 8 vCPUs instead of the default 8 cores × 2 threads = 16 vCPUs. Windows licensing is charged per vCPU, so you pay for 8 licenses instead of 16.
+
+## Applies To
+
+- **EC2 Windows** — Windows Server License Included instances
+- **SQL Server on EC2** — SQL Server License Included instances (Standard and Enterprise)
+- **RDS for SQL Server** — Understanding vCPU-based licensing costs
+
+## Related Resources
+
+- [AWS EC2 CPU Options Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html)
+- [Microsoft Licensing on AWS](https://aws.amazon.com/windows/resources/licensing/)
+- [EC2 Pricing and Availability Script](/Code%20Repo/EC2_Pricing_and_Availability/) — Find instance availability across regions
+
+## Author
+
+Craig Cooley (coolcrai@) — Built with Kiro IDE

--- a/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
+++ b/docusaurus/docs/Licensing/Guides/Optimize_CPU_Costs/index.md
@@ -1,27 +1,31 @@
 ---
 sidebar_position: 4
 title: Optimize CPU Costs for Windows Licensing
-description: Reduce Microsoft per-core licensing costs on EC2 by adjusting ThreadsPerCore settings
+description: Reduce Microsoft license included costs on EC2 by adjusting ThreadsPerCore settings
 ---
 
 # Optimize CPU Costs for Windows Licensing
 
-Reduce Microsoft per-core licensing costs on Amazon EC2 and SQL Server instances by disabling hyperthreading (setting ThreadsPerCore = 1). This PowerShell script calculates potential savings and helps you understand the cost impact across instance types.
+Reduce Microsoft licensing costs on Amazon EC2 and SQL Server instances by disabling hyperthreading (setting `ThreadsPerCore = 1`). This PowerShell script calculates potential savings and helps you understand the cost impact across instance types.
 
 ## Why This Matters
 
-Windows Server and SQL Server are licensed **per physical core** on AWS. By default, most EC2 instance types enable 2 threads per core (hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
+Windows Server and SQL Server are licensed **per active vCPU** on AWS. By default, most EC2 instance types have 2 VCPUs per physical core (hyperthreading). If your workload doesn't benefit from hyperthreading, you're paying for twice the licensing you need.
 
-Setting `ThreadsPerCore = 1` at launch:
-- **Halves your Windows/SQL licensing cost** (License Included pricing is per-vCPU)
-- May be appropriate for memory-bound or I/O-bound workloads
-- Does not affect the on-demand compute cost — only the license component
+Setting `ThreadsPerCore = 1`:
+- **Halves your Windows/SQL licensing cost** (License Included pricing is per active vCPU)
+- Does not affect the compute cost — only the license component
+- see [Optimize CPUs for License-Included instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize-cpu.html) for details
 
-## Script
+## Scripts
 
-The `Show-OptimizeCPUCosts` script demonstrates cost savings across instance types by querying the AWS Pricing API and comparing License Included costs with and without hyperthreading.
+The scripts in the [Scripts](./Scripts/) folder demonstrate cost savings across instance types by querying the AWS Pricing API and comparing License Included costs with and without hyperthreading.
 
-**Repository:** [gitlab.aws.dev/coolcrai/Show-OptimizeCPUCosts](https://gitlab.aws.dev/coolcrai/Show-OptimizeCPUCosts)
+| Script | Description |
+|--------|-------------|
+| `Show-OptimizedCpuCost.ps1` | Shows per-instance cost savings when disabling hyperthreading |
+| `Show-AccountCpuOptimization.ps1` | Scans instances in your account and shows optimization opportunities |
+| `Set-ThreadsPerCore.yaml` | SSM Automation document to set ThreadsPerCore on existing instances |
 
 ### Requirements
 
@@ -33,7 +37,7 @@ The `Show-OptimizeCPUCosts` script demonstrates cost savings across instance typ
 
 ```powershell
 pwsh
-.\Show-OptimizeCPUCosts.ps1 -InstanceType m7a.4xlarge -Region us-east-1
+.\Show-OptimizedCpuCost.ps1 -InstanceType m8i.4xlarge -Region us-east-1
 ```
 
 ## How ThreadsPerCore Works
@@ -41,7 +45,7 @@ pwsh
 When launching an EC2 instance, you can specify CPU options:
 
 ```powershell
-New-EC2Instance -InstanceType m7a.4xlarge `
+New-EC2Instance -InstanceType m8i.4xlarge `
     -CpuOption_ThreadsPerCore 1 `
     -CpuOption_CoreCount 8
 ```
@@ -51,15 +55,8 @@ This launches with 8 cores × 1 thread = 8 vCPUs instead of the default 8 cores 
 ## Applies To
 
 - **EC2 Windows** — Windows Server License Included instances
-- **SQL Server on EC2** — SQL Server License Included instances (Standard and Enterprise)
-- **RDS for SQL Server** — Understanding vCPU-based licensing costs
-
-## Related Resources
-
-- [AWS EC2 CPU Options Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html)
-- [Microsoft Licensing on AWS](https://aws.amazon.com/windows/resources/licensing/)
-- [EC2 Pricing and Availability Script](/Code%20Repo/EC2_Pricing_and_Availability/) — Find instance availability across regions
-
+- **SQL Server on EC2** — SQL Server License Included instances 
+- **RDS for SQL Server** — Latest RDS instance have `ThreadsPerCore = 1` by default
 ## Author
 
 Craig Cooley (coolcrai@) — Built with Kiro IDE


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds a new guide under Licensing/Guides for "Optimize CPU Costs for Windows Licensing". This page documents how to reduce Microsoft per-core licensing costs on EC2 by adjusting ThreadsPerCore settings (disabling hyperthreading).

Includes:
- Explanation of why ThreadsPerCore matters for Windows/SQL licensing
- Link to the Show-OptimizeCPUCosts script on GitLab
- Quick start instructions for AWS CloudShell
- Code example showing CPU options at launch
- Cross-references to related resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.